### PR TITLE
Feature/sysvar token highlighting

### DIFF
--- a/syntaxes/gsl.tmLanguage.json
+++ b/syntaxes/gsl.tmLanguage.json
@@ -88,6 +88,10 @@
 							"name": "keyword.gsl.messaging.special",
 							"match": "\\b(?i)(?:mode)\\b"
 						},
+						{
+							"name": "keyword.gsl.msgrgm.modes",
+							"match": "\\b(?i)(?:dbg|debugging|tongues|signal|whisper|sneaking|info|experience|combat|creature|infra|infrastructure|magic|crafting|guild)\\b"
+						},
 						{ "include": "#node_vars" },
 						{ "include": "#numbers" },
 						{ "include": "#strings" },
@@ -110,7 +114,7 @@
 				},
 				{
 					"name": "statement.gsl.messaging.targeted",
-					"begin": "\\b(?i)(msg)\\s?(n[pr]\\d)?",
+					"begin": "\\b(?i)(msg|prempt)\\s?(n[pr]\\d)?",
 					"beginCaptures": {
 						"1": { "name": "keyword.gsl.messaging" },
 						"2": { "name": "variable.gsl.node" }
@@ -123,7 +127,7 @@
 				},
 				{
 					"name": "statement.gsl.callmatch",
-					"match": "(?ix) \\b (callmatch) \\s+? (?: (must_match|may_match|check)? \\s+? ( \\$\\w* | \"[^\"]*?\" )? \\s+? (in)? )?",
+					"match": "(?ix) \\b (callmatch) \\s+? (?: (must_match|may_match|check)? \\s+? \\(?( \\$\\w* | [s|t][0-9] | \"[^\"]*?\" )?\\)? \\s+? (in)? )?",
 					"captures": {
 						"1": { "name": "keyword.gsl.callmatch" },
 						"2": { "name": "keyword.gsl.callmatch.param" },
@@ -154,7 +158,7 @@
 					"end": "$",
 					"patterns": [
 						{
-							"name": "keyword.gsl.param.effects",
+							"name": "keyword.gsl.effects.param",
 							"match": "\\b(?i:code|value1|value2|flags|with|in|script)\\b"
 						},
 						{ "include": "#expression" }
@@ -162,14 +166,14 @@
 				},
 				{
 					"name": "statement.gsl.effects",
-					"begin": "\\b(?i)((?:test|rem)2?(?:effect))\\b",
+					"begin": "\\b(?i)((?:test2?|rem(n|2)?)(?:effect))\\b",
 					"beginCaptures": {
 						"1": { "name": "keyword.gsl.effects" }
 					},
 					"end": "$",
 					"patterns": [
 						{
-							"name": "keyword.gsl.param.effects",
+							"name": "keyword.gsl.effects.param",
 							"match": "\\b(?i)(code|value2|from)\\b"
 						},
 						{ "include": "#expression" }
@@ -245,6 +249,39 @@
 							"match": "\\b(?i)(call|callback|donematch)\\b"
 						},
 						{ "include": "#variables" },
+						{ "include": "#comments" }
+					]
+				},
+				{
+					"name": "statement.gsl.combat",
+					"begin": "\\b(?i)(hurt|injure)\\b",
+					"beginCaptures": {
+						"1": { "name": "keyword.gsl.combat" }
+					},
+					"end": "$",
+					"patterns": [
+						{
+							"name": "keyword.gsl.combat.param",
+							"match": "\\b(?i:hits)\\b"
+						},
+						{ "include": "#variables" },
+						{ "include": "#comments" }
+					]
+				},
+				{
+					"name": "statement.gsl.assignment",
+					"begin": "\\b(?i)(index|random)\\b",
+					"beginCaptures": {
+						"1": { "name": "keyword.gsl.assignment" }
+					},
+					"end": "$",
+					"patterns": [
+						{
+							"name": "keyword.gsl.assignment.param",
+							"match": "\\b(?i:for|to)\\b"
+						},
+						{ "include": "#variables" },
+						{ "include": "#numbers" },
 						{ "include": "#comments" }
 					]
 				}
@@ -328,7 +365,7 @@
 				},
 				{
 					"name": "keyword.gsl.info",
-					"match": "\\b(?i:index|info|getnameof|table|profile|script)\\b"
+					"match": "\\b(?i:info|getnameof|table|profile|script)\\b"
 				},
 				{
 					"name": "keyword.gsl.table",
@@ -365,6 +402,14 @@
 				{
 					"name": "keyword.gsl.dangerous",
 					"match": "\\b(?i:kill|killallnp|removevargroup|removevarfield)\\b"
+				},
+				{
+					"name": "keyword.gsl.misc",
+					"match": "\\b(?i:lookroom|dolook|diradd|dirsend)\\b"
+				},
+				{
+					"name": "keyword.gsl.assignment",
+					"match": "\\b(?i:random|index)\\b"
 				}
 			]
 		},
@@ -409,6 +454,15 @@
 				{
 					"name": "token.gsl.misc",
 					"match": "\\$(\\$|\\\\|\\^|\\*|\\+|'|Q|R|ZE)"
+				},
+				{
+					"name": "token.gsl.sysvar",
+					"begin": "\\$\\:\\$(?=\\w)",
+					"end": "(?=\\W)",
+					"patterns": [
+						{ "include": "#number_system_vars" },
+						{ "include": "#string_system_vars" }
+					]
 				},
 				{
 					"name": "token.gsl.xml",
@@ -497,6 +551,15 @@
 					"captures": {
 						"1": { "name": "variable.gsl.table" }
 					}
+				},
+				{
+					"name": "variable.gsl.system",
+					"begin": "\\$(?=\\w)",
+					"end": "(?=\\W)",
+					"patterns": [
+						{ "include": "#number_system_vars" },
+						{ "include": "#string_system_vars" }
+					]
 				}
 			]
 		},
@@ -511,15 +574,17 @@
 				}
 			]
 		},
+		"number_system_vars": {
+			"match": "(?i:ERROR|BREAK|THISSCRIPT|CALLEDBY|INTTABLE|STRTABLE|DESCMODE|LOADINGFROMSAVE|USERS|MAXUOBJS|MAXTEXTCHANGES|SYSTIME|TIME)\\b"
+		},
+		"string_system_vars": {
+			"match": "(?i:MATCH|GAMECODE|GAMENAME|REPLYADDRESS|SHORTNAME|TIMES)\\b"
+		},
 		"string_vars": {
 			"patterns": [
 				{
 					"name": "variable.gsl.register.string",
 					"match": "\\b(?i)[ST]\\d\\b"
-				},
-				{
-					"name": "variable.gsl.system.string",
-					"match": "\\$(?i:MATCH|GAMECODE|GAMENAME|REPLYADDRESS|SHORTNAME|TIMES)\\b"
 				}
 			]
 		},
@@ -528,10 +593,6 @@
 				{
 					"name": "variable.gsl.register.number",
 					"match": "\\b(?i)[ABV]\\d\\b"
-				},
-				{
-					"name": "variable.gsl.system.number",
-					"match": "\\$(?i:ERROR|BREAK|THISSCRIPT|CALLEDBY|INTTABLE|STRTABLE|DESCMODE|LOADINGFROMSAVE|USERS|MAXUOBJS|MAXTEXTCHANGES|SYSTIME|TIME)\\b"
 				}
 			]
 		}

--- a/themes/gsl_naos.json
+++ b/themes/gsl_naos.json
@@ -1,0 +1,185 @@
+{
+    "name": "Naos In The Sky",
+	"type": "dark",
+	"$schema": "vscode://schemas/color-theme",
+	"include": "./dark_plus.json",
+	"tokenColors": [
+        {
+            "scope": "comment.gsl.scan.index",
+            "settings": {
+                "foreground": "#ABA77A"
+            }
+        },
+        {
+            "scope": "comment.gsl.scan.index.ten",
+            "settings": {
+                "foreground": "#A97354"
+            }
+        },
+        {
+            "scope": "string.quoted.double.gsl",
+            "settings": {
+                "foreground": "#83AE6E"
+            }
+        },
+        {
+            "scope": "constant.numeric.gsl",
+            "settings": {
+                "foreground": "#A9977E"
+            }
+        },
+        {
+            "scope": "source.gsl",
+            "settings": {
+                "foreground": "#D3D3D3"
+            }
+        },
+        {
+            "scope": "keyword.gsl.stop",
+            "settings": {
+                "foreground": "#CB8B15",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "scope": "keyword.gsl.dangerous",
+            "settings": {
+                "foreground": "#C12C27",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "scope": "keyword.gsl.assert",
+            "settings": {
+                "foreground": "#BD5B58",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "scope": "matchmarker.gsl",
+            "settings": {
+                "foreground": "#D7A738",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "scope": "keyword.gsl.stack",
+            "settings": {
+                "foreground": "#D9B86C",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "scope": "token.gsl",
+            "settings": {
+                "foreground": "#2A992A"
+            }
+        },
+        {
+            "scope": "token.gsl.sysvar",
+            "settings": {
+                "foreground": "#1b631b"
+            }
+        },
+        {
+            "scope": "token.gsl.xml.attribute.name",
+            "settings": {
+                "foreground": "#144714"
+            }
+        },
+        {
+            "scope": "keyword.gsl",
+            "settings": {
+                "foreground": "#999999"
+            }
+        },
+        {
+            "scope": "keyword.gsl.control",
+            "settings": {
+                "foreground": "#6980AF"
+            }
+        },
+        {
+            "scope": "keyword.gsl.gathering",
+            "settings": {
+                "foreground": "#BAA364"
+            }
+        },
+        {
+            "scope": "keyword.gsl.callmatch",
+            "settings": {
+                "foreground": "#5E6D89"
+            }
+        },
+        {
+            "scope": "keyword.gsl.messaging",
+            "settings": {
+                "foreground": "#588B8A"
+            }
+        },
+        {
+            "scope": "keyword.gsl.assignment",
+            "settings": {
+                "foreground": "#6C3794"
+            }
+        },
+        {
+            "scope": "keyword.gsl.table",
+            "settings": {
+                "foreground": "#9254c2"
+            }
+        },
+        {
+            "scope": "keyword.gsl.effects",
+            "settings": {
+                "foreground": "#497897"
+            }
+        },
+        {
+            "scope": "operator.gsl.special",
+            "settings": {
+                "foreground": "#8AACEC"
+            }
+        },
+        {
+            "scope": "variable.gsl",
+            "settings": {
+                "foreground": "#8B70A6"
+            }
+        },
+        {
+            "scope": "variable.gsl.system",
+            "settings": {
+                "foreground": "#0068FF"
+            }
+        },
+        {
+            "scope": "variable.gsl.node",
+            "settings": {
+                "foreground": "#967D38"
+            }
+        },
+        {
+            "scope": "variable.gsl.field",
+            "settings": {
+                "foreground": "#C3A348"
+            }
+        },
+        {
+            "scope": "keyword.gsl.addgroup",
+            "settings": {
+                "foreground": "#C3A348"
+            }
+        },
+        {
+            "scope": "keyword.gsl.msgrgm.modes",
+            "settings": {
+                "foreground": "#7a738a"
+            }
+        }
+   ],
+    "colors": {
+        "editorLineNumber.activeForeground": "#999999",
+        "editorIndentGuide.activeBackground": "#999999"  
+    }
+}


### PR DESCRIPTION
adds support for highlighting system variable string tokens (e.g. $:$THISSCRIPT)
adds some missing gsl keywords as keyword.gsl.misc
adds some more detail to the callmatch statement to cover some more weird cases
adds support for msgrgm named modes as keyword.gsl.msgrgm.modes scope
fixes effects param scopes to be keyword.gsl.effects.param instead of keyword.gsl.param.effects

adds Naos In The Sky theme for maximum gsl colors