### PR TITLE
Add snippet-assisted hover?

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -34,6 +34,7 @@ const GSLX_DEV_PASSWORD = 'developmentPassword'
 const GSLX_NEW_INSTALL_FLAG = 'gslExtNewInstallFlag'
 const GSLX_SAVED_VERSION = 'savedVersion'
 const GSLX_DISABLE_LOGIN = 'disableLoginAttempts'
+const GSLX_ENABLE_SNIPPET_ASSISTED_HOVER = 'enableSnippetAssistedHover'
 const rx_script_number = /^\d{1,5}$/
 
 export class GSLExtension {
@@ -595,7 +596,11 @@ export function activate (context: ExtensionContext) {
     context.subscriptions.push(subscription)
 
     subscription = languages.registerHoverProvider(
-        selector, new GSLHoverProvider()
+        selector,
+        new GSLHoverProvider({
+            "useSnippets": !!workspace.getConfiguration(GSL_LANGUAGE_ID)
+                .get(GSLX_ENABLE_SNIPPET_ASSISTED_HOVER)
+        })
     )
     context.subscriptions.push(subscription)
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,13 @@
           "default": false,
           "description": "Enable to permanently disable login attempts from various actions in the editor."
         },
+        "gsl.enableSnippetAssistedHover": {
+            "type": [
+              "boolean"
+            ],
+            "default": false,
+            "description": "Enable to utilize snippets to enhance hover information."
+          },
         "gsl.alwaysEnabled": {
           "type": [
             "boolean"

--- a/snippets/GslSnippets.ts
+++ b/snippets/GslSnippets.ts
@@ -1,0 +1,9 @@
+import * as untypedSnippets from './gsl.json';
+
+export interface GslSnippet {
+    prefix: string
+    body: string[]
+    description: string
+}
+
+export const snippets = untypedSnippets as { [name: string]: GslSnippet }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["ES2022"],
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
 		"outDir": ".",


### PR DESCRIPTION
Patrick -

I'm curious if you think this is worth adding. The desire is to add hover tips for commands, which snippets provide a loose approximation of. It has been helpful for me in my research, so I figured it may be useful to others as well. It is toggleable via a setting that defaults to disabled.


-------------

<img width="274" alt="image" src="https://github.com/pltrant/GSL-Editor/assets/1661498/e771e1bb-16a8-46eb-8c7b-49055a3e7024">

-------------

<img width="279" alt="image" src="https://github.com/pltrant/GSL-Editor/assets/1661498/177f9a02-87d1-4998-a061-53aa631c3baf">

-------------

<img width="393" alt="image" src="https://github.com/pltrant/GSL-Editor/assets/1661498/a456216e-52ac-440b-8cc6-dd1ed39a8359">


-------------

The `snippets/gsl.json` file contains a wealth of information on commands. This commit allows the hover provider to match snippets based on the first word in their prefix, displaying the corresponding snippet descriptions in markdown.

In the case where multiple snippets match, all of the descriptions are shown. One such case is `callmatch`. A more sophisticated implementation of this commit might resolve to a single snippet, but it may also be desirable to show the user alternative usages. I'm on the fence.

It may also be cleaner to separate the descriptions from the snippets, but that is a much larger diff, and would require dynamically building the snippets from multiple files. If that direction is desired, then it might be worth considering moving `gsl.json` to a typescript file.

Finally, note that this commit adds `resolveJsonModule: true` to the tsconfig so that json files are importable in typescript.