### PR TITLE
Add safety features for uploading scripts

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -67,7 +67,7 @@ export class GSLExtension {
         return extPath
     }
 
-    static async downloadScript (script: number | string, gotoDef?: string) {
+    static async downloadScript (script: number | string) {
         const error: any = (e: Error) => { error.caught = e }
         const downloadPath = this.getDownloadLocation()
         const fileExtension = workspace.getConfiguration(GSL_LANGUAGE_ID).get('fileExtension')
@@ -86,21 +86,10 @@ export class GSLExtension {
                     fs.writeFileSync(scriptPath, content)
                 }
             }
-            // open the script file and maybe navigagte to definition
-            const document = await workspace.openTextDocument(scriptPath)
-            const editor = await window.showTextDocument(document, { preview: false })
-            if (gotoDef) {
-                const gotoRegExp = new RegExp(`:\s+${gotoDef}`)
-                for (let n = 0, nn = document.lineCount; n < nn; n++) {
-                    const line = document.lineAt(n)
-                    if (line.text.match(gotoRegExp)) {
-                        commands.executeCommand('revealLine', { lineNumber: n, at: 'center' })
-                        break
-                    }
-                }
-            }
             this.vsc.recordScriptProperties(script, scriptProperties)
             window.setStatusBarMessage("Script download complete!", 5000)
+            const document = await workspace.openTextDocument(scriptPath)
+            await window.showTextDocument(document, { preview: false })
         } else {
             window.showErrorMessage("Could not connect to game?")
         }

--- a/extension.ts
+++ b/extension.ts
@@ -34,6 +34,7 @@ const GSLX_DEV_PASSWORD = 'developmentPassword'
 const GSLX_NEW_INSTALL_FLAG = 'gslExtNewInstallFlag'
 const GSLX_SAVED_VERSION = 'savedVersion'
 const GSLX_DISABLE_LOGIN = 'disableLoginAttempts'
+const GSLX_AUTOMATIC_DOWNLOADS = 'automaticallyDownloadScripts'
 const rx_script_number = /^\d{1,5}$/
 
 export class GSLExtension {
@@ -675,7 +676,10 @@ export function activate (context: ExtensionContext) {
     context.subscriptions.push(subscription)
 
     subscription = languages.registerDefinitionProvider(
-        selector, new GSLDefinitionProvider()
+        selector,
+        new GSLDefinitionProvider(
+            !!workspace.getConfiguration(GSL_LANGUAGE_ID).get(GSLX_AUTOMATIC_DOWNLOADS)
+        )
     )
     context.subscriptions.push(subscription)
 

--- a/gsl/definitionProvider.ts
+++ b/gsl/definitionProvider.ts
@@ -6,6 +6,11 @@ import * as fs from "fs"
 import { GSLExtension } from "../extension";
 
 export class GSLDefinitionProvider implements DefinitionProvider {
+  private enableAutomaticDownloads: boolean
+
+  constructor(enableAutomaticDownloads: boolean) {
+    this.enableAutomaticDownloads = enableAutomaticDownloads
+  }
 
   async provideDefinition (document: any, position: any, token: any) {
     let txt = document.lineAt(position.line).text.trim().toLowerCase()
@@ -36,6 +41,11 @@ export class GSLDefinitionProvider implements DefinitionProvider {
         let scriptFile = path.join(GSLExtension.getDownloadLocation(), 'S' + scriptNum)
                        + workspace.getConfiguration('gsl').get('fileExtension')
         if (!fs.existsSync(scriptFile)) {
+          if (!this.enableAutomaticDownloads) {
+            throw new Error(
+              'Failed to find script and automatic downloads are disabled'
+            )
+          }
           await GSLExtension.downloadScript(Number(scriptNum))
         }
         if (!fs.existsSync(scriptFile)) {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,13 @@
           "default": 100,
           "description": "Maximum number of problems reported for document"
         },
+        "gsl.automaticallyDownloadScripts": {
+          "type": [
+            "boolean"
+          ],
+          "default": true,
+          "description": "If enabled, scripts will be automatically downloaded when their matchmarker definitions are needed."
+        },
         "gsl.disableLoginAttempts": {
           "type": [
             "boolean"


### PR DESCRIPTION
This PR has three commits:
- Require confirmation when a script upload appears destructive
- Fixes an issue where a file navigation would occur when a MM definition is requested by the editor
- Adds an option to disable automatic downloads (option is off by default to preserve the existing UX, but happy to change that default if you'd prefer)