### PR TITLE
Snippet hover pr

### DIFF
--- a/gsl/definitionProvider.ts
+++ b/gsl/definitionProvider.ts
@@ -42,9 +42,8 @@ export class GSLDefinitionProvider implements DefinitionProvider {
                        + workspace.getConfiguration('gsl').get('fileExtension')
         if (!fs.existsSync(scriptFile)) {
           if (!this.enableAutomaticDownloads) {
-            throw new Error(
-              'Failed to find script and automatic downloads are disabled'
-            )
+            console.warn('File not found and automatic downloads disabled')
+            return
           }
           await GSLExtension.downloadScript(Number(scriptNum))
         }

--- a/snippets/GslSnippets.ts
+++ b/snippets/GslSnippets.ts
@@ -1,0 +1,9 @@
+import * as untypedSnippets from './gsl.json';
+
+export interface GslSnippet {
+    prefix: string
+    body: string[]
+    description: string
+}
+
+export const snippets = untypedSnippets as { [name: string]: GslSnippet }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["ES2022"],
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
 		"outDir": ".",


### PR DESCRIPTION
Adds snippet-assisted hover as well as updates a `definitionProvider` error to a warning. The latter should have no user impact but seems more correct. See commit messages and original PR https://github.com/pltrant/GSL-Editor/pull/37 for more detail.