### PR TITLE
Fix safety guard for longer account names

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -188,7 +188,9 @@ export class GSLExtension {
             )
         }
         const currentAccount = this.vsc.getAccountName()
-        if (currentAccount !== newestProperties.modifier) {
+        // The server truncates the account name to 12 characters, so we have to rely on startsWith.
+        // This means that we have no ability to distinguish between modifiers W_GS4-Alornen and W_GS4-Alorner
+        if (!currentAccount?.startsWith(newestProperties.modifier)) {
             reasons.push(
                 `Someone else modified it last.\nLast Modifier: ${newestProperties.modifier}\nYou: ${currentAccount}`
             )


### PR DESCRIPTION
The `/ms` command truncates the modifier name in it's output. This commit updates the "last modifier" safety check to account for this truncation.