### PR TITLE
Restore "Compile OK" status bar message

### DIFF
--- a/gsl/editorClient.ts
+++ b/gsl/editorClient.ts
@@ -35,6 +35,7 @@ export interface ScriptCompileResults {
     script: number,
     path: string,
     bytes: number,
+    maxBytes: number,
     errors: number,
     warnings: number,
     errorList: Array<ScriptError>
@@ -269,7 +270,7 @@ export class EditorClient extends BaseGameClient {
     sendScript (lines: Array<string>, newScript: boolean): Promise<ScriptCompileResults> {
         return new Promise ((resolve, reject) => {
             const compileResults: ScriptCompileResults = {
-                script: 0, path: '', bytes: 0, errors: 0, warnings: 0, errorList: [], status: ScriptCompileStatus.Unknown
+                script: 0, path: '', bytes: 0, maxBytes: 0, errors: 0, warnings: 0, errorList: [], status: ScriptCompileStatus.Unknown
             }
             const output = new OutputProcessor ((line: string) => {
                 let match: RegExpMatchArray | null
@@ -303,6 +304,7 @@ export class EditorClient extends BaseGameClient {
                     compileResults.status = ScriptCompileStatus.Compiled
                     compileResults.warnings = Number(match.groups.warnings)
                     compileResults.bytes = Number(match.groups.bytes.replace(/,/g, ''))
+                    compileResults.maxBytes = Number(match.groups.maxBytes.replace(/,/g, ''))
                     return
                 }
                 match = line.match(rx_compile_fail)


### PR DESCRIPTION
This message was inadvertantly removed by 92ab1d, which added a call to `getScriptProperties()` in `uploadScript()`. As a result, the `getScriptProperties()` call would overwrite the "Compile OK" message with a "Script xxx was last modified..." message.

This commit pulls instances of `window.setStatusBarMessage()` out of `getScriptProperties()` and `uploadScript()` and into the top-level command methods `commandCheckDate()` and `commandUploadScript()`. This allows inner methods to call one another without worrying about sending a message to the user (note that error messages will still be surfaced - it may be a good idea to pull that logic out as well in the future).

This commit also displays bytes remaining against the script size limit.