### PR TITLE
Record script properties using script number

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -24,7 +24,7 @@ import {
 import { EAccessClient } from './gsl/eaccessClient'
 import { GameClientOptions } from './gsl/gameClients'
 import { GameTerminal } from './gsl/gameTerminal'
-import { ScriptCompileStatus, ScriptError, EditorClient, ScriptProperties, SerializedScriptProperties, ScriptCompileResults } from './gsl/editorClient'
+import { ScriptCompileStatus, ScriptError, EditorClient, ScriptProperties, ScriptCompileResults, ShowScriptOutput } from './gsl/editorClient'
 
 const GSL_LANGUAGE_ID = 'gsl'
 const GSLX_DEV_ACCOUNT = 'developmentAccount'
@@ -36,6 +36,12 @@ const GSLX_SAVED_VERSION = 'savedVersion'
 const GSLX_DISABLE_LOGIN = 'disableLoginAttempts'
 const GSLX_AUTOMATIC_DOWNLOADS = 'automaticallyDownloadScripts'
 const rx_script_number = /^\d{1,5}$/
+const rx_script_number_in_filename = /(\d+)\.gsl/
+
+interface LastSeenScriptModification {
+    modifier: string
+    lastModifiedDate: Date
+}
 
 export class GSLExtension {
     private static vsc: VSCodeIntegration
@@ -88,7 +94,11 @@ export class GSLExtension {
                     fs.writeFileSync(scriptPath, content)
                 }
             }
-            this.vsc.recordScriptProperties(script, scriptProperties)
+            this.vsc.recordScriptModification(
+                Number(scriptFile.match(rx_script_number_in_filename)![1]),
+                scriptProperties.modifier,
+                scriptProperties.lastModifiedDate,
+            )
             window.setStatusBarMessage("Script download complete!", 5000)
             return scriptPath
         } else {
@@ -135,9 +145,9 @@ export class GSLExtension {
             } else {
                 this.diagnostics.clear()
                 // Record updated script properties
-                const props = await GSLExtension.getScriptProperties(script)
-                if (!props || !props.lastModifiedDate) throw new Error('Failed to update local script properties')
-                this.vsc.recordScriptProperties(script, props)
+                const output = await GSLExtension.getShowScriptOutput(script)
+                if (!output) throw new Error('Failed to record script modification')
+                this.vsc.recordScriptModification(script, output.modifier, output.lastModifiedDate)
             }
             return compileResults
         } else {
@@ -146,28 +156,28 @@ export class GSLExtension {
     }
 
     static async checkModifiedDate (script: number): Promise<Date | undefined> {
-        const props = await GSLExtension.getScriptProperties(script)
-        if (!props || !props.lastModifiedDate) return
-        return props.lastModifiedDate
+        const output = await GSLExtension.getShowScriptOutput(script)
+        if (!output || !output.lastModifiedDate) return
+        return output.lastModifiedDate
     }
 
-    static async getScriptProperties (script: number): Promise<ScriptProperties | undefined> {
+    static async getShowScriptOutput (script: number): Promise<ShowScriptOutput | undefined> {
         const error: any = (e: Error) => { error.caught = e }
         const client = await this.vsc.ensureGameConnection().catch(error)
         if (error.caught) { return void window.showErrorMessage(`Failed to connect to game: ${error.caught.message}`) }
-        let scriptProperties = await client.checkScript(script).catch(error)
-        if (error.caught) { return void window.showErrorMessage(`Failed to check modification date: ${error.caught.message}`) }
-        return scriptProperties
+        const output = await client.showScript(script).catch(error)
+        if (error.caught) { return void window.showErrorMessage(`Failed to get /ss output: ${error.caught.message}`) }
+        return output
     }
 
     static requiresUploadConfirmation (
         script: number,
         newestProperties: ScriptProperties
     ): { prompt: string } | undefined {
-        const lastProperties = this.vsc.lookupScriptProperties(script)
+        const lastSeenMod = this.vsc.findLastSeenScriptModification(script)
         let reasons = []
 
-        if (!lastProperties || !lastProperties.lastModifiedDate || !lastProperties.modifier) {
+        if (!lastSeenMod || !lastSeenMod.lastModifiedDate || !lastSeenMod.modifier) {
             reasons.push(
                 `I haven't seen you download this script before. This could be because you downloaded the script prior`
                 + ` to the safety guard being added. If you want to be extra safe, you can download the script from the`
@@ -176,10 +186,10 @@ export class GSLExtension {
                 + ` should overwrite the server copy.`
             )
         }
-        else if (lastProperties.lastModifiedDate.toISOString() !== newestProperties.lastModifiedDate.toISOString()) {
+        else if (lastSeenMod.lastModifiedDate.toISOString() !== newestProperties.lastModifiedDate.toISOString()) {
             reasons.push(
                 `It appears to have been edited since you last downloaded it.`
-                + `\nServer: ${newestProperties.lastModifiedDate}\nLocal: ${lastProperties.lastModifiedDate}`
+                + `\nServer: ${newestProperties.lastModifiedDate}\nLocal: ${lastSeenMod.lastModifiedDate}`
             )
         }
         const currentAccount = this.vsc.getAccountName()
@@ -193,8 +203,8 @@ export class GSLExtension {
 
         return reasons.length === 0 ? undefined : {
             prompt:
-                `Overwriting script ${script} requires confirmation for the following reasons:\n\n`
-                + reasons.map((r, i) => `${i + 1}) ${r}`).join('\n\n')
+                `Overwriting script ${script} requires confirmation for the following reason(s):\n\n`
+                + reasons.join('\n\n')
                 + `\n\nWould you like to upload this script anyway?`,
         }
     }
@@ -488,7 +498,8 @@ class VSCodeIntegration {
         this.context.subscriptions.push(subscription)
     }
 
-    private scriptPropsKey(script: string | number): string {
+    /** @returns key for storing script modification data */
+    private scriptPropsKey(script: number): string {
         return `script_properties.${script}`
     }
 
@@ -614,16 +625,28 @@ class VSCodeIntegration {
         const name = this.context.globalState.get(GSLX_DEV_ACCOUNT)
         if (!name) return
         return `W_${name}`
-
     }
 
-    recordScriptProperties(script: string | number, props: ScriptProperties): void {
-        this.context.globalState.update(this.scriptPropsKey(script), ScriptProperties.serialize(props))
+    recordScriptModification(
+        script: number,
+        modifier: string,
+        lastModifiedDate: Date
+    ): void {
+        if (Number.isNaN(script)) throw new Error('Expected script number, not NaN')
+        this.context.globalState.update(
+            this.scriptPropsKey(script),
+            { modifier, lastModifiedDate: lastModifiedDate.toISOString() }
+        )
     }
 
-    lookupScriptProperties(script: string | number): ScriptProperties | undefined {
-        const props = this.context.globalState.get<SerializedScriptProperties>(this.scriptPropsKey(script))
-        return props ? ScriptProperties.deserialize(props) : undefined
+    findLastSeenScriptModification(script: number): LastSeenScriptModification | undefined {
+        const output = this.context.globalState.get<{modifier: string, lastModifiedDate: string}>(
+            this.scriptPropsKey(script)
+        )
+        return output ? {
+            modifier: output.modifier,
+            lastModifiedDate: new Date(output.lastModifiedDate) // restore from ISO string
+        } : undefined
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,13 @@
           "default": true,
           "description": "If enabled, scripts will be automatically downloaded when their matchmarker definitions are needed."
         },
+        "gsl.enableScriptSyncChecks": {
+          "type": [
+            "boolean"
+          ],
+          "default": true,
+          "description": "Enable to check sync status when downloading scripts."
+        },
         "gsl.disableLoginAttempts": {
           "type": [
             "boolean"


### PR DESCRIPTION
This solves an issue where the extension wouldn't distinguish between a script downloaded with it's verb name versus it's script number. Backwards compatibility with the old globalState values should be preserved.

Rather than storing all script properties, we now only store the last modifier and last modified time. This is because those properties are the only ones that we use, and because the output of `/ss` does not give us all properties - we want to avoid a roundtrip with `/m[sv]`.

This commit also increases the type safety of `editorClient.ts`:
- Distinguish between the return type of `checkScript` and `modifyScript`. The former is a subset of the latter.
- Add some type safety to those same methods while building up the return value. Two `as any` casts still remain but these would need a larger change to address, likely requiring one regex per property.
- Properly mark `ScriptProperties.new` as optional