### PR TITLE
Prevent empty script upload

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -120,6 +120,9 @@ export class GSLExtension {
     }
 
     static async uploadScript (script: number, document: TextDocument): Promise<ScriptCompileResults | undefined> {
+        if (document.getText().match(/^\s*$/)) {
+            return void window.showErrorMessage('Cannot upload empty script')
+        }
         const error: any = (e: Error) => { error.caught = e }
         const client = await this.vsc.ensureGameConnection().catch(error)
         if (error.caught) { return void window.showErrorMessage(`Failed to connect to game: ${error.caught.message}`) }


### PR DESCRIPTION
Empty scripts cannot be compiled, so there is no good reason to upload them. Also, the `editorClient.ts` doesn't handle the operation and results in an infinite loop. This commit shows an error to the user instead of attempting to upload empty scripts.

Fixes #30