### PR TITLE
Mar 27 2025 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ scripts/
 *.vsix
 node_modules
 compile.txt
+.vscode-test/
+tsconfig.tsbuildinfo

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+    "require": ["ts-node/register"],
+    "extension": ["ts"],
+    "watchExtensions": ["ts"],
+    "spec": ["test/suite/**/*.test.ts"]
+}

--- a/extension.ts
+++ b/extension.ts
@@ -410,7 +410,7 @@ export class VSCodeIntegration {
     /* commands */
 
     private async commandDownloadScript () {
-        const prompt = 'Script number or verb name to download?'
+        const prompt = 'Script number(s) or verb name(s) to download?'
         const input = await window.showInputBox({ prompt })
         if (!input) { return }
         const scriptOptions = input.replace(/\s/g, '').split(';')

--- a/gsl/codeActionProvider.ts
+++ b/gsl/codeActionProvider.ts
@@ -2,7 +2,11 @@ import * as vscode from 'vscode';
 
 import { CodeActionProvider, CodeAction, CodeActionKind, Range, TextDocument, WorkspaceEdit } from 'vscode'
 import { LINE_TOO_LONG } from './diagnostics';
-import { fixLineTooLong } from './util/formattingUtil';
+import { fixLineTooLong, collapseMultiline, isWrappedString } from './util/formattingUtil';
+
+export const ACTION_REDISTRIBUTE_MULTILINE = 'Redistribute Multiline String';
+export const ACTION_COLLAPSE_MULTILINE = 'Collapse Multiline String';
+export const ACTION_WRAP_TO_MULTIPLE = 'Wrap to Multiple Lines';
 
 export class GSLCodeActionProvider implements CodeActionProvider {
     public static readonly providedCodeActionKinds = [
@@ -10,18 +14,87 @@ export class GSLCodeActionProvider implements CodeActionProvider {
     ];
 
     provideCodeActions(document: TextDocument, range: Range, context: vscode.CodeActionContext): CodeAction[] {
-        // Only trigger for diagnostics with code "line-too-long"
-        if (!context.diagnostics.some(diag => String(diag.code) === LINE_TOO_LONG)) {
-            return [];
-        }
+        const actions: CodeAction[] = [];
         const line = document.lineAt(range.start.line);
-        const fixed = fixLineTooLong(line.text)
-        if (line.text === fixed) return [];
 
-        const action = new CodeAction('Wrap to multiple lines', CodeActionKind.QuickFix);
-        const edit = new WorkspaceEdit();
-        edit.replace(document.uri, line.range, fixed);
-        action.edit = edit;
-        return [action]
+        // Add Collapse Multiline String action if the line can be collapsed
+        if (isWrappedString(line.text)) {
+            let startLine = line
+            // Seek to start of wrapped string
+            while (startLine.range.start.line > 1) {
+                const prevLine = document.lineAt(startLine.range.start.line - 1)
+                if (!isWrappedString(prevLine.text)) break
+                startLine = prevLine
+            }
+            let endLine = startLine.range.start.line;
+            let fullText = startLine.text;
+
+            // Keep reading lines until we find one that doesn't end with \
+            while (endLine < document.lineCount - 1) {
+                const nextLine = document.lineAt(endLine + 1);
+                if (!nextLine.text.trimEnd().endsWith('\\')) {
+                    fullText += '\n' + nextLine.text;
+                    endLine++;
+                    break;
+                }
+                fullText += '\n' + nextLine.text;
+                endLine++;
+            }
+
+            // Identify range
+            const multiLineRange = new Range(
+                startLine.range.start.line,
+                0,
+                endLine,
+                document.lineAt(endLine).text.length
+            );
+
+            // Add Redistribute Multiline String
+            const redistributed = fixLineTooLong(collapseMultiline(fullText));
+            if (redistributed !== fullText) {
+                const redistributeEdit = new WorkspaceEdit();
+                redistributeEdit.replace(
+                    document.uri,
+                    multiLineRange,
+                    redistributed
+                );
+                const redistributeAction = new CodeAction(
+                    ACTION_REDISTRIBUTE_MULTILINE,
+                    CodeActionKind.RefactorInline
+                );
+                redistributeAction.edit = redistributeEdit;
+                actions.push(redistributeAction);
+            }
+
+            // Add Collapse Multiline String
+            const collapseEdit = new WorkspaceEdit();
+            collapseEdit.replace(
+                document.uri,
+                multiLineRange,
+                collapseMultiline(fullText)
+            );
+            const collapseAction = new CodeAction(
+                ACTION_COLLAPSE_MULTILINE,
+                CodeActionKind.RefactorInline
+            );
+            collapseAction.edit = collapseEdit;
+            actions.push(collapseAction);
+        }
+
+        // Add Wrap action if line is too long
+        if (context.diagnostics.some(diag => String(diag.code) === LINE_TOO_LONG)) {
+            const fixed = fixLineTooLong(line.text);
+            if (line.text !== fixed) {
+                const wrapAction = new CodeAction(
+                    ACTION_WRAP_TO_MULTIPLE,
+                    CodeActionKind.QuickFix
+                );
+                const wrapEdit = new WorkspaceEdit();
+                wrapEdit.replace(document.uri, line.range, fixed);
+                wrapAction.edit = wrapEdit;
+                actions.push(wrapAction);
+            }
+        }
+        return actions;
     }
 }

--- a/gsl/codeActionProvider.ts
+++ b/gsl/codeActionProvider.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+import { CodeActionProvider, CodeAction, CodeActionKind, Range, TextDocument, WorkspaceEdit } from 'vscode'
+import { LINE_TOO_LONG } from './diagnostics';
+import { fixLineTooLong } from './util/formattingUtil';
+
+export class GSLCodeActionProvider implements CodeActionProvider {
+    public static readonly providedCodeActionKinds = [
+        vscode.CodeActionKind.QuickFix
+    ];
+
+    provideCodeActions(document: TextDocument, range: Range, context: vscode.CodeActionContext): CodeAction[] {
+        // Only trigger for diagnostics with code "line-too-long"
+        if (!context.diagnostics.some(diag => String(diag.code) === LINE_TOO_LONG)) {
+            return [];
+        }
+        const line = document.lineAt(range.start.line);
+        const fixed = fixLineTooLong(line.text)
+        if (line.text === fixed) return [];
+
+        const action = new CodeAction('Wrap to multiple lines', CodeActionKind.QuickFix);
+        const edit = new WorkspaceEdit();
+        edit.replace(document.uri, line.range, fixed);
+        action.edit = edit;
+        return [action]
+    }
+}

--- a/gsl/codeActionProvider.ts
+++ b/gsl/codeActionProvider.ts
@@ -1,21 +1,33 @@
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 
-import { CodeActionProvider, CodeAction, CodeActionKind, Range, TextDocument, WorkspaceEdit } from 'vscode'
-import { LINE_TOO_LONG } from './diagnostics';
-import { fixLineTooLong, collapseMultiline, isWrappedString } from './util/formattingUtil';
+import { CodeActionProvider, CodeAction, CodeActionKind, Range, TextDocument, TextLine, WorkspaceEdit } from 'vscode'
+import { LINE_TOO_LONG, MAX_LINE_LENGTH } from './diagnostics'
+import { fixLineTooLong, collapseMultiline, isWrappedString, getMessageCommand, MessageCommand } from './util/formattingUtil'
 
-export const ACTION_REDISTRIBUTE_MULTILINE = 'Redistribute Multiline String';
-export const ACTION_COLLAPSE_MULTILINE = 'Collapse Multiline String';
-export const ACTION_WRAP_TO_MULTIPLE = 'Wrap to Multiple Lines';
+export const COMBINE_MULTIPLE_MESSAGES = 'Combine Messages'
+export const ACTION_REDISTRIBUTE_MULTILINE = 'Redistribute Multiline String'
+export const ACTION_COLLAPSE_MULTILINE = 'Collapse Multiline String'
+export const ACTION_WRAP_TO_MULTIPLE = 'Wrap to Multiple Lines'
+export const ACTION_ALIGN_COMMENTS = 'Align Comments'
 
 export class GSLCodeActionProvider implements CodeActionProvider {
     public static readonly providedCodeActionKinds = [
         vscode.CodeActionKind.QuickFix
-    ];
+    ]
 
-    provideCodeActions(document: TextDocument, range: Range, context: vscode.CodeActionContext): CodeAction[] {
-        const actions: CodeAction[] = [];
-        const line = document.lineAt(range.start.line);
+    provideCodeActions(
+        document: TextDocument,
+        range: Range,
+        context: vscode.CodeActionContext
+    ): CodeAction[] {
+        const actions: CodeAction[] = []
+        const line = document.lineAt(range.start.line)
+
+        // Add Combine Multiple Messages action if multiple messages exist in sequence
+        const combineMessagesAction = getCombineMessagesAction(document, line)
+        if (combineMessagesAction) {
+            actions.push(combineMessagesAction)
+        }
 
         // Add Collapse Multiline String action if the line can be collapsed
         if (isWrappedString(line.text)) {
@@ -26,19 +38,19 @@ export class GSLCodeActionProvider implements CodeActionProvider {
                 if (!isWrappedString(prevLine.text)) break
                 startLine = prevLine
             }
-            let endLine = startLine.range.start.line;
-            let fullText = startLine.text;
+            let endLine = startLine.range.start.line
+            let fullText = startLine.text
 
             // Keep reading lines until we find one that doesn't end with \
             while (endLine < document.lineCount - 1) {
-                const nextLine = document.lineAt(endLine + 1);
+                const nextLine = document.lineAt(endLine + 1)
                 if (!nextLine.text.trimEnd().endsWith('\\')) {
-                    fullText += '\n' + nextLine.text;
-                    endLine++;
-                    break;
+                    fullText += '\n' + nextLine.text
+                    endLine++
+                    break
                 }
-                fullText += '\n' + nextLine.text;
-                endLine++;
+                fullText += '\n' + nextLine.text
+                endLine++
             }
 
             // Identify range
@@ -47,54 +59,137 @@ export class GSLCodeActionProvider implements CodeActionProvider {
                 0,
                 endLine,
                 document.lineAt(endLine).text.length
-            );
+            )
 
             // Add Redistribute Multiline String
-            const redistributed = fixLineTooLong(collapseMultiline(fullText));
+            const redistributed = fixLineTooLong(collapseMultiline(fullText))
             if (redistributed !== fullText) {
-                const redistributeEdit = new WorkspaceEdit();
+                const redistributeEdit = new WorkspaceEdit()
                 redistributeEdit.replace(
                     document.uri,
                     multiLineRange,
                     redistributed
-                );
+                )
                 const redistributeAction = new CodeAction(
                     ACTION_REDISTRIBUTE_MULTILINE,
                     CodeActionKind.RefactorInline
-                );
-                redistributeAction.edit = redistributeEdit;
-                actions.push(redistributeAction);
+                )
+                redistributeAction.edit = redistributeEdit
+                actions.push(redistributeAction)
             }
 
             // Add Collapse Multiline String
-            const collapseEdit = new WorkspaceEdit();
+            const collapseEdit = new WorkspaceEdit()
             collapseEdit.replace(
                 document.uri,
                 multiLineRange,
                 collapseMultiline(fullText)
-            );
+            )
             const collapseAction = new CodeAction(
                 ACTION_COLLAPSE_MULTILINE,
                 CodeActionKind.RefactorInline
-            );
-            collapseAction.edit = collapseEdit;
-            actions.push(collapseAction);
+            )
+            collapseAction.edit = collapseEdit
+            actions.push(collapseAction)
         }
 
         // Add Wrap action if line is too long
         if (context.diagnostics.some(diag => String(diag.code) === LINE_TOO_LONG)) {
-            const fixed = fixLineTooLong(line.text);
+            const fixed = fixLineTooLong(line.text)
             if (line.text !== fixed) {
                 const wrapAction = new CodeAction(
                     ACTION_WRAP_TO_MULTIPLE,
                     CodeActionKind.QuickFix
-                );
-                const wrapEdit = new WorkspaceEdit();
-                wrapEdit.replace(document.uri, line.range, fixed);
-                wrapAction.edit = wrapEdit;
-                actions.push(wrapAction);
+                )
+                const wrapEdit = new WorkspaceEdit()
+                wrapEdit.replace(document.uri, line.range, fixed)
+                wrapAction.edit = wrapEdit
+                actions.push(wrapAction)
             }
         }
-        return actions;
+        return actions
     }
+}
+
+const getNextLine = (document: TextDocument, line: TextLine): TextLine | null => {
+    return line.range.end.line === document.lineCount
+        ? null
+        : document.lineAt(line.range.start.line + 1)
+}
+
+const isSequenceOfMessageCmd = (
+    document: TextDocument,
+    line: TextLine,
+    lineCmd: MessageCommand
+): boolean => {
+    if (!lineCmd.skipNewline) return false
+    const nextLine = getNextLine(document, line)
+    if (!nextLine) return false
+    const nextLineCmd = getMessageCommand(nextLine.text)
+    if (!nextLineCmd) return false
+    return lineCmd.command.toLowerCase() === nextLineCmd.command.toLowerCase()
+}
+
+const getCombineMessagesAction = (
+    document: TextDocument,
+    line: TextLine
+): CodeAction | undefined => {
+    const messageCmd = getMessageCommand(line.text)
+    if (!messageCmd || !isSequenceOfMessageCmd(document, line, messageCmd)) {
+        return
+    }
+    let content = messageCmd.content
+    let comments = [messageCmd.comment].filter(Boolean)
+    let endLine = line.range.start.line
+
+    // Keep reading lines until we find one that isn't in the sequence
+    while (endLine < document.lineCount - 1) {
+        const nextCmd = getMessageCommand(document.lineAt(endLine + 1).text)
+        if (
+            !nextCmd
+            || messageCmd.command.toLowerCase() !== nextCmd.command.toLowerCase()
+        ) {
+            break
+        }
+        content += nextCmd.content
+        if (nextCmd.comment) comments.push(nextCmd.comment)
+        endLine++
+    }
+
+    // Determine whether the whole sequence ends in a newline
+    if (getMessageCommand(document.lineAt(endLine).text)?.skipNewline) {
+        content += '$\\'
+    }
+
+    // Identify range
+    const multiLineRange = new Range(
+        line.range.start.line,
+        0,
+        endLine,
+        document.lineAt(endLine).text.length
+    )
+
+    // Create result text
+    let result = fixLineTooLong(
+        collapseMultiline(
+            `${messageCmd.indentation}${messageCmd.command} "${content}"`
+        )
+    )
+    comments.forEach(comment => {
+        result += `\n${messageCmd.indentation}! ${comment}`
+    })
+
+    // Create action
+    const combineEdit = new WorkspaceEdit();
+    combineEdit.replace(
+        document.uri,
+        multiLineRange,
+        result
+    );
+    const combineAction = new CodeAction(
+        COMBINE_MULTIPLE_MESSAGES,
+        CodeActionKind.RefactorInline
+    )
+    combineAction.edit = combineEdit
+    return combineAction
 }

--- a/gsl/diagnostics.ts
+++ b/gsl/diagnostics.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+
+export const LINE_TOO_LONG = 'line-too-long';
+export const MAX_LINE_LENGTH = 118;
+
+export function subscribeToDocumentChanges(
+    context: vscode.ExtensionContext,
+    lineLengthDiagnostics: vscode.DiagnosticCollection
+): void {
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument(e => refreshDiagnostics(e.document, lineLengthDiagnostics)),
+        vscode.workspace.onDidOpenTextDocument(doc => refreshDiagnostics(doc, lineLengthDiagnostics))
+    );
+    // Refresh diagnostics for already open documents
+    vscode.workspace.textDocuments.forEach(doc => refreshDiagnostics(doc, lineLengthDiagnostics));
+}
+
+function refreshDiagnostics(
+    document: vscode.TextDocument,
+    lineLengthDiagnostics: vscode.DiagnosticCollection
+): void {
+    const diagnostics: vscode.Diagnostic[] = [];
+
+    for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
+        const lineOfText = document.lineAt(lineIndex);
+        if (lineOfText.text.length > MAX_LINE_LENGTH) {
+            const diagnostic = createLineLengthDiagnostic(lineOfText, MAX_LINE_LENGTH);
+            diagnostics.push(diagnostic);
+        }
+    }
+
+    lineLengthDiagnostics.set(document.uri, diagnostics);
+}
+
+function createLineLengthDiagnostic(
+    lineOfText: vscode.TextLine,
+    maxLineLength: number
+): vscode.Diagnostic {
+    const message = `Line is too long (${lineOfText.text.length} > ${maxLineLength} characters)`;
+    const range = lineOfText.range; // highlight the entire line
+    const diagnostic = new vscode.Diagnostic(
+        range,
+        message,
+        vscode.DiagnosticSeverity.Warning
+    );
+    diagnostic.code = LINE_TOO_LONG;
+    return diagnostic;
+}

--- a/gsl/highlightProvider.ts
+++ b/gsl/highlightProvider.ts
@@ -1,99 +1,426 @@
+import {
+    DocumentHighlightProvider,
+    DocumentHighlight,
+    DocumentHighlightKind,
+    Range,
+    TextDocument,
+    Position,
+    TextLine
+} from "vscode"
+import { isNonVoid } from "./util/typeUtil"
 
-import { DocumentHighlightProvider, DocumentHighlight, DocumentHighlightKind, TextDocument, Position, ProviderResult } from "vscode"
-import { CancellationToken } from "vscode-languageclient"
+const MAX_SCAN_ITERATIONS = 10000; // Prevent excessive scanning
+
+// Token regexes. First capture group must capture the appropriate token. See `readToken`.
+const MM_START = /^\s*(:\s*".*?")/i
+const BLOCK_START = /^\s*(ifnot|if|loop|when|is|default|:\s*".*?")/i
+const DOT = /^\s*(\.)/i
+const PUSH = /^\s*(fastpush|push)/i
+const POP = /^\s*(fastpop|pop)/i
+const IF = /^\s*(ifnot|if)/i
+const ELSE = /^\s*(else_ifnot|else_if|else)/i
+const CASE_STATEMENT = /^\s*(is|default)/i
+const STOP = /^\s*(stop)/i
+
+/** Given a line, return the matched token type, or undefined if not found. */
+const readToken = <T extends string>(
+    lineText: string,
+    regex: RegExp,
+): T | undefined => {
+    const match = lineText.match(regex)
+    return match ? match[1]?.toLowerCase() as T : undefined
+}
+
+const isFirstSymbolOnLine = (line: TextLine, position: Position, wordRange?: Range): boolean => {
+    // Handle dot case
+    if (
+        readToken(line.text, DOT) && (
+            line.text.indexOf('.') === position.character
+            || line.text.indexOf('.') === position.character - 1
+        )
+    ) return true
+    // Handle normal word case
+    if (!wordRange) return false
+    return line.firstNonWhitespaceCharacterIndex === wordRange.start.character
+}
+
+const isThenSymbol = (line: TextLine, word?: string): boolean => {
+    return word?.toLowerCase() === 'then' && (
+        Boolean(readToken(line.text, BLOCK_START) || readToken(line.text, ELSE))
+    )
+}
+
+const isMatchmarkerStart = (line: TextLine, position: Position): boolean => {
+    const mmStartMatch = line.text.match(MM_START)
+    if (!mmStartMatch) return false
+    return mmStartMatch[0].length >= position.character
+}
 
 export class GSLDocumentHighlightProvider implements DocumentHighlightProvider {
-    private startKeywords: RegExp
-    private middleKeywords: RegExp
-    private endKeywords: RegExp
-    private gslWords: RegExp
+    provideDocumentHighlights(document: TextDocument, position: Position): DocumentHighlight[] {
+        const line = document.lineAt(position.line)
+        const wordRange = document.getWordRangeAtPosition(position, /\b\w+\b/)
+        const word = wordRange ? document.getText(wordRange) : undefined
 
-    constructor() {
-        this.startKeywords = /^:|^\s*(if|ifnot|loop|when|is|default|fastpush|push)\b.*$/i
-        this.middleKeywords = /^\s*(else|else_if|else_ifnot)\b.*$/i
-        this.endKeywords = /^\s*\.|(fastpop|pop)\b.*$/i
-        this.gslWords = /:|\.|if|ifnot|loop|when|is|default|else_ifnot|else_if|else|fastpush|fastpop|push|pop/i
+        if (
+            isFirstSymbolOnLine(line, position, wordRange)
+            || isThenSymbol(line, word)
+            || isMatchmarkerStart(line, position)
+        ) {
+            // Handle DOT, ELSE, and case statements, rerunnning this function with the opener.
+            let blockEnd = readToken(line.text, DOT)
+                || readToken(line.text, ELSE)
+                || readToken(line.text, CASE_STATEMENT)
+            if (blockEnd) {
+                const startOfBlock = this.findStartOfBlock(document, position)
+                if (startOfBlock) {
+                    // Rerun with start of block for consistent logic
+                    return this.provideDocumentHighlights(document, startOfBlock)
+                }
+                return [highlightMatch(document, position.line, blockEnd)]
+            }
+
+            // Try processing line as block start.
+            const blockStart = readToken(line.text, BLOCK_START)
+            if (blockStart) {
+                return [
+                    // Highlight all of blockStart so that the MM line is fully highlighted:
+                    highlightMatch(document, position.line, blockStart),
+                    ...this.scanForwardsHighlightBlockTokens(document, position, blockStart)
+                ]
+            }
+
+            // Handle case of "push|fastpush" by searching for corresponding pops.
+            const push = readToken<'push' | 'fastpush'>(line.text, PUSH)
+            if (push) {
+                return [
+                    highlightMatch(document, position.line, push),
+                    ...this.scanForwardHighlightPops(document, position, push)
+                ]
+            }
+
+            // Handle case of "pop|fastpop" by searching for corresponding push.
+            const pop = readToken<'pop' | 'fastpop'>(line.text, POP)
+            if (pop) {
+                return [
+                    highlightMatch(document, position.line, pop),
+                    this.scanBackwardHighlightPushes(document, position, pop)
+                ].filter(isNonVoid)
+            }
+        }
+
+        // Nothing matched. Just highlight the word range of the original position (if any).
+        if (!word) return []
+        const highlights: DocumentHighlight[] = []
+        
+        for (let lineNum = 0; lineNum < document.lineCount; lineNum++) {
+            const lineText = document.lineAt(lineNum).text
+            let match: RegExpExecArray | null
+            const regex = new RegExp(`\\b${word}\\b`, 'gi')
+            
+            while ((match = regex.exec(lineText)) !== null) {
+                const range = new Range(
+                    new Position(lineNum, match.index),
+                    new Position(lineNum, match.index + word.length)
+                )
+                highlights.push(new DocumentHighlight(range, DocumentHighlightKind.Text))
+            }
+        }
+        
+        return highlights
     }
 
-    provideDocumentHighlights(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<DocumentHighlight[]> {
-        let highlights = []
-        let textRange = document.getWordRangeAtPosition(position, /[\S]+/)
-        if (textRange) {
-            let lineNum = textRange.start.line
-            let starts = 0
-            let ends = 0
+    /**
+     * Given a block opener token at `position`, i.e.
+     * "ifnot/if/loop/when/is/default" or a MM label line, scan forwards
+     * and highlight the corresponding block closing token (a dot).
+     * 
+     * In the case of "if/ifnot", the "else/else_if/else_ifnot" tokens
+     * will also be highlighted.
+     * 
+     * In the case of "when", the IS/DEFAULT tokens are highlighted.
+     */
+    private scanForwardsHighlightBlockTokens(
+        document: TextDocument,
+        position: Position,
+        originalMatch: string
+    ): DocumentHighlight[] {
+        const highlights = new Array<DocumentHighlight>()
+        const blockStack = [originalMatch]
+        let iterations = 0
 
-            if (this.startKeywords.test(document.getText(textRange))) {
-                highlights.push(new DocumentHighlight(textRange, DocumentHighlightKind.Text))
-                this.searchLinesAfter(document, lineNum, highlights, starts, ends)
-            } else if (this.middleKeywords.test(document.getText(textRange))) {
-                highlights.push(new DocumentHighlight(textRange, DocumentHighlightKind.Text))
-                // Check for the starting keyword
-                ends = 1
-                this.searchLinesBefore(document, lineNum, highlights, starts, ends)
-                // Check for the ending keyword
-                lineNum = textRange.start.line
-                starts = 1
-                ends = 0
-                this.searchLinesAfter(document, lineNum, highlights, starts, ends)
-            } else if (this.endKeywords.test(document.getText(textRange))) {
-                highlights.push(new DocumentHighlight(textRange, DocumentHighlightKind.Text))
-                this.searchLinesBefore(document, lineNum, highlights, starts, ends)
+        // If statements should have THEN highlighted
+        if (originalMatch === 'if' || originalMatch === 'ifnot') {
+            const thenHighlight = highlightThenSymbol(document, position.line)
+            if (thenHighlight) highlights.push(thenHighlight)
+        }
+
+        // Scan forward to find the corresponding pair at the same level of the stack
+        for (
+            let i = position.line + 1;
+            i < document.lineCount && iterations < MAX_SCAN_ITERATIONS;
+            i++, iterations++
+        ) {
+            const topOfStack = peekStack(blockStack)
+            if (!topOfStack) return highlights
+
+            // Handle IS/DEFAULT, a special kind of block start
+            const line = document.lineAt(i)
+            if (originalMatch === 'when' && blockStack.length === 1) {
+                const caseStatement = readToken(line.text, CASE_STATEMENT)
+                if (caseStatement) {
+                    highlights.push(highlightMatch(document, i, caseStatement))
+                }
+            }
+            if (originalMatch === 'when' && blockStack.length === 2) {
+                const endCaseStatement = readToken(line.text, DOT)
+                if (endCaseStatement) {
+                    highlights.push(highlightMatch(document, i, endCaseStatement))
+                }
+            }
+
+            // Handle block start
+            const blockStartMatch = readToken(line.text, BLOCK_START)
+            if (blockStartMatch) {
+                blockStack.push(blockStartMatch)
+                continue
+            }
+
+            // Handle ELSE
+            if (originalMatch.startsWith('if') && blockStack.length === 1) {
+                const elseMatch = readToken(line.text, ELSE)
+                if (elseMatch) {
+                    highlights.push(highlightMatch(document, i, elseMatch))
+                    const thenHighlight = highlightThenSymbol(document, i)
+                    if (thenHighlight) highlights.push(thenHighlight)
+                    continue
+                }
+            }
+
+            // Handle DOT
+            const dot = readToken(line.text, DOT)
+            if (dot && isPair(topOfStack, dot)) {
+                blockStack.pop()
+                // Uncomment this if we want to highlights dots in WHEN:
+                // if (originalMatch === 'when' && blockStack.length === 1) {
+                //     highlights.push(highlightMatch(document, i, dot))
+                //     continue
+                // }
+                if (!blockStack.length) {
+                    highlights.push(highlightMatch(document, i, dot))
+                }
+                continue
+            }
+        }
+
+        return highlights
+    }
+
+    /**
+     * Given a "." statement at `position`, scans backwards to find
+     * the position of the start of the block.
+     */
+    private findStartOfBlock(
+        document: TextDocument,
+        position: Position
+    ): Position | undefined {
+        const blockStack = new Array<string>('.')
+        let iterations = 0
+
+        // Scan backward to find the corresponding pair at the same level of the stack
+        for (
+            let i = position.line - 1;
+            i >= 0 && iterations < MAX_SCAN_ITERATIONS;
+            i--, iterations++
+        ) {
+            const topOfStack = peekStack(blockStack)
+            if (!topOfStack) return
+            const line = document.lineAt(i)
+
+            // Handle block start
+            const blockStart = readToken(line.text, BLOCK_START)
+            if (blockStart) {
+                if (!blockStack.length) return // In case text is malformed
+
+                // Pop stack and return if start of pair is found
+                blockStack.pop()
+                if (!blockStack.length) {
+                    return new Position(i, line.text.toLowerCase().indexOf(blockStart))
+                }
+            }
+
+            // Handle DOT
+            const dot = readToken(line.text, DOT)
+            if (dot) {
+                blockStack.push(dot)
+                continue
+            }
+        }
+    }
+
+    /**
+     * Given a "pop/fastpop" statement at `position`, scans backward to find
+     * and highlight the corresponding "push/fastpush" statement.
+     */
+    private scanBackwardHighlightPushes(
+        document: TextDocument,
+        position: Position,
+        originalMatch: 'pop' | 'fastpop'
+    ): DocumentHighlight | undefined {
+        /**
+         * A reverse block stack. When a block ending is seen it is pushed on,
+         * and when a block beginning is seen the last block ending is
+         * popped off. Unlike in other places, we treat fastpush/push/
+         * fastpop/pop as block symbols.
+         */
+        const blockStack = new Array<string>(originalMatch)
+        let earlyStop = false
+        let iterations = 0
+
+        // Scan backwards to find the corresponding push
+        for (
+            let i = position.line - 1;
+            i >= 0 && iterations < MAX_SCAN_ITERATIONS;
+            i--, iterations++
+        ) {
+            const line = document.lineAt(i)
+            const pushMatch = readToken(line.text, PUSH)
+
+            if (readToken(line.text, STOP)) {
+                earlyStop = true
+                continue
+            }
+
+            if (blockStack.length <= 1) {
+                // Try processing as the corresponding push
+                if (pushMatch && isPair(pushMatch, originalMatch)) {
+                    return highlightMatch(document, i, pushMatch)
+                }
+            }
+
+            // Try processing as block start, including pushes
+            const blockStart = pushMatch ?? readToken(line.text, BLOCK_START)
+            if (blockStart) {
+                earlyStop = false
+                if (blockStack.length > 0) blockStack.pop()
+                continue
+            }
+
+            // Try processing as block start, including pops
+            const blockEnd = readToken(line.text, POP)
+                ?? readToken(line.text, DOT)
+            if (blockEnd) {
+                if ((blockEnd === 'pop' || blockEnd === 'fastpop') && earlyStop) {
+                    continue // Ignore early pop stops
+                }
+                blockStack.push(blockEnd)
+                continue
+            }
+        }
+    }
+
+    /**
+     * Given a "push/fastpush" statement at `position`, scans forward to find
+     * and highlight the corresponding "pop/fastpop" statements. Because of
+     * early stops, multiple highlights may be returned.
+     */
+    private scanForwardHighlightPops(
+        document: TextDocument,
+        position: Position,
+        originalMatch: 'push' | 'fastpush'
+    ): DocumentHighlight[] {
+        const highlights = new Array<DocumentHighlight>()
+        /**
+         * A block stack. When a block beginning is seen it is pushed on,
+         * and when a block ending is seen then the last beginning is popped.
+         */
+        const blockStack = new Array<string>(originalMatch)
+        let pushDepth = 1
+        let iterations = 0
+
+        // Scan forward to find all pops associated with the given push match
+        for (
+            let i = position.line + 1;
+            i < document.lineCount && iterations < MAX_SCAN_ITERATIONS;
+            i++, iterations++
+        ) {
+            const topOfStack = peekStack(blockStack)
+            if (!topOfStack) return highlights
+            const line = document.lineAt(i)
+
+            // Try processing as block start
+            const blockStart = readToken(line.text, BLOCK_START)
+            if (blockStart) {
+                blockStack.push(blockStart)
+                continue
+            }
+
+            // Try processing as block end
+            const blockEnd = readToken(line.text, DOT)
+            if (blockEnd) {
+                if (isPair(topOfStack, blockEnd)) blockStack.pop()
+                continue
+            }
+
+            // Try processing as push
+            const pushMatch = readToken(line.text, PUSH)
+            if (pushMatch) {
+                blockStack.push(pushMatch)
+                pushDepth++
+                continue
+            }
+
+            // Try processing as pop
+            const popMatch = readToken(line.text, POP)
+            if (popMatch) {
+                if (isPair(originalMatch, popMatch) && pushDepth === 1) {
+                    // Highlight push
+                    highlights.push(highlightMatch(document, i, popMatch))
+                }
+                if (isPair(topOfStack, popMatch)) {
+                    // Remove last pop from stack
+                    blockStack.pop()
+                    pushDepth--
+                }
             }
         }
         return highlights
     }
+}
 
-    searchLinesAfter(document: TextDocument, lineNum: number, highlights: DocumentHighlight[], starts: number, ends: number) {
-        let foundEnd = false
-        let textLine = ''
-        while (foundEnd === false) {
-            textLine = document.lineAt(lineNum).text
-            if (this.startKeywords.test(textLine)) {
-                starts++
-            } else if ((starts === ends + 1) && (this.middleKeywords.test(textLine))) {
-                this.addHighlight(highlights, document, lineNum, textLine)
-            } else if (this.endKeywords.test(textLine)) {
-                ends++
-            }
-            if (starts === ends) {
-                this.addHighlight(highlights, document, lineNum, textLine)
-                foundEnd = true
-            }
-            lineNum++
-        }
-    }
+const peekStack = <T>(stack: T[]): T | null => stack.length
+    ? stack[stack.length - 1]
+    : null
 
-    searchLinesBefore(document: TextDocument, lineNum: number, highlights: DocumentHighlight[], starts: number, ends: number) {
-        let foundEnd = false
-        let textLine = ''
-        while (foundEnd === false) {
-            textLine = document.lineAt(lineNum).text
-            if (this.startKeywords.test(textLine)) {
-                starts++
-            } else if ((starts + 1 === ends) && (this.middleKeywords.test(textLine))) {
-                this.addHighlight(highlights, document, lineNum, textLine)
-            } else if (this.endKeywords.test(textLine)) {
-                ends++
-            }
-            if (starts === ends) {
-                this.addHighlight(highlights, document, lineNum, textLine)
-                foundEnd = true
-            }
-            lineNum--
-        }
-    }
+const highlightThenSymbol = (
+    document: TextDocument,
+    lineNum: number
+): DocumentHighlight | undefined => {
+    const thenMatch = document.lineAt(lineNum).text.toLowerCase().indexOf('then')
+    if (thenMatch === -1) return
+    return highlightMatch(document, lineNum, 'then')
+}
 
-    addHighlight(highlights: DocumentHighlight[], document: TextDocument, lineNum: number, textLine: string) {
-        let startIdx = textLine.search(/\S|$/)
-        if (startIdx > -1) {
-            let endPos = new Position(lineNum, startIdx)
-            if (endPos) {
-                let endRange = document.getWordRangeAtPosition(endPos, this.gslWords)
-                if (endRange) {
-                    highlights.push(new DocumentHighlight(endRange))
-                }
-            }
-        }
-    }
+const highlightMatch = (
+    document: TextDocument,
+    lineNum: number,
+    match: string
+): DocumentHighlight => {
+    const lineText = document.lineAt(lineNum).text.toLowerCase()
+    const startIndex = lineText.indexOf(match)
+    const startPos = new Position(lineNum, startIndex)
+    const endPos = new Position(lineNum, startIndex + match.length)
+    const range = new Range(startPos, endPos)
+    return new DocumentHighlight(range, DocumentHighlightKind.Text)
+}
+
+const isPair = (
+    blockStartMatch: string,
+    blockEndMatch: string,
+): boolean => {
+    const start = blockStartMatch
+    const end = blockEndMatch
+    if (start === 'fastpush') return end === 'fastpop'
+    if (start === 'push') return end === 'pop'
+    return end === '.'
 }

--- a/gsl/util/formattingUtil.ts
+++ b/gsl/util/formattingUtil.ts
@@ -1,0 +1,74 @@
+import { MAX_LINE_LENGTH } from "../diagnostics";
+
+export const QUOTE_CONTINUATION = `" +\\\n`
+
+const REGEX = /^(\s*)(msgp|msg\s+NP\d+|msgr|msgrxp|msgrx2|set.*?to)\s*\(?"(.*)"\s*(!.*)?/i;
+
+/**
+ * Decompose input across multiple lines, respecting MAX_LINE_LENGTH.
+ */
+export const fixLineTooLong = (input: string): string => {
+    if (input.length <= MAX_LINE_LENGTH) return input;
+
+    // Supported commands: msg, msgp, msg NP0/NP1/NP5, msgrxp, set T0 to, etc.
+    const match = input.match(REGEX);
+    if (!match) return input;
+
+    // Consume buffer
+    const [_, indentation, __, ___, comment] = match
+    let result = ""
+    let bufferIn = ensureParantheses(input.trimEnd())
+
+    while (bufferIn.length) {
+        if (result) {
+            // Indent line if it isn't the first
+            bufferIn = indentation + '"' + bufferIn
+        }
+        [result, bufferIn] = nextWrap(result, bufferIn)
+    }
+
+    if (comment?.trim()) {
+        // Move comment to next line and let user handle it
+        result += `\n${indentation}${comment.trim()}`
+    }
+
+    return result;
+}
+
+const ensureParantheses = (text: string): string => {
+    const match = text.match(REGEX);
+    if (!match) return text;
+    const [_, indentation, command, content] = match;
+    return `${indentation}${command} ("${content}")`;
+}
+
+const nextWrap = (result: string, bufferIn: string): [string, string] => {
+    if (bufferIn.length <= MAX_LINE_LENGTH) {
+        // Remaining text fits in one line. Append it and return empty buffer.
+        return [result + bufferIn, ''];
+    }
+    const maxLength = MAX_LINE_LENGTH - 3 // Leave 3 for quote continuation
+    // Find the last space before max length
+    let cutIndex = -1
+    let inSpaceSequence = false
+    for (let i = 0; i < bufferIn.length; i++) {
+        if (i >= maxLength) break
+        if (bufferIn[i] === " " && !inSpaceSequence) {
+            cutIndex = i
+        }
+        inSpaceSequence = Boolean(bufferIn[i] === " ")
+    }
+    if (cutIndex === -1) {
+        // If no space found, force cut at max possible length
+        cutIndex = maxLength
+    }
+
+    // Split the buffer
+    const currentLine = bufferIn.substring(0, cutIndex);
+    const remainingBuffer = bufferIn.substring(cutIndex);
+
+    // Add line continuation marker if there's more text
+    const suffix = remainingBuffer ? QUOTE_CONTINUATION : '';
+
+    return [result + currentLine + suffix, remainingBuffer];
+};

--- a/gsl/util/formattingUtil.ts
+++ b/gsl/util/formattingUtil.ts
@@ -1,21 +1,22 @@
-import { MAX_LINE_LENGTH } from "../diagnostics";
+import { TextDocument } from "vscode"
+import { MAX_LINE_LENGTH } from "../diagnostics"
 
 export const QUOTE_CONTINUATION = `" +\\\n`
-export const WRAPPED_TEXT_LINE_REGEX = /"\s*\+\s*\\$/;
-export const MESSAGE_LINE_REGEX = /^(\s*)(msgp|msg\s+NP\d|msgr|msgrxp|msgrx2)\s+"(.*?)(\$\\)?"\s*(!\s*.*)?/i;
-const WRAPPABLE_LINE_REGEX = /^(\s*)(msgp|msg\s+NP\d|msgr|msgrxp|msgrx2|set.*?to)\s*\(?"(.*)"\s*(!.*)?/i;
+export const WRAPPED_TEXT_LINE_REGEX = /"\s*\+\s*\\$/
+export const MESSAGE_LINE_REGEX = /^(\s*)(msgp|msg\s+NP\d|msgr|msgrxp|msgrx2)\s+"(.*?)(\$\\)?"\s*(!\s*.*)?/i
+const WRAPPABLE_LINE_REGEX = /^(\s*)(msgp|msg\s+NP\d|msgr|msgrxp|msgrx2|set.*?to)\s*\(?"(.*)"\s*(!.*)?/i
 
 export interface MessageCommand {
     /** A series of space characters. */
-    indentation: string;
+    indentation: string
     /** @example 'msgp' | 'msg NP0' | 'msgr' */
-    command: string;
+    command: string
     /** @example 'Hello World' */
-    content: string;
+    content: string
     /** True if the line ended with a $\ symbol. */
-    skipNewline: boolean;
+    skipNewline: boolean
     /** Contains the trailing comment, if one exists. */
-    comment: string | null;
+    comment: string | null
 }
 
 /**
@@ -37,7 +38,7 @@ export const isWrappedString = (text: string): boolean => Boolean(
 export const getMessageCommand = (text: string): MessageCommand | null => {
     const match = text.match(MESSAGE_LINE_REGEX)
     if (match) {
-        const [_, indentation, command, content, skipNewlineSymbol, comment] = match;
+        const [_, indentation, command, content, skipNewlineSymbol, comment] = match
         return {
             indentation,
             command,
@@ -54,7 +55,7 @@ const stripUnnecessaryParans = (text: string): string => {
         return text; // Multiline. Parans is necessary.
     }
     const match = text.match(WRAPPABLE_LINE_REGEX)
-    if (!match) return text;
+    if (!match) return text
     const [_, indentation, command, content, comment] = match
     const withoutParans = `${indentation}${command} "${content}"${comment || ''}`
     return (withoutParans.length <= MAX_LINE_LENGTH) ? withoutParans : text
@@ -69,8 +70,8 @@ export const fixLineTooLong = (input: string): string => {
     if (withoutParans.length <= MAX_LINE_LENGTH) return withoutParans
 
     // Supported commands: msg, msgp, msg NP0/NP1/NP5, msgrxp, set T0 to, etc.
-    const match = input.match(WRAPPABLE_LINE_REGEX);
-    if (!match) return input;
+    const match = input.match(WRAPPABLE_LINE_REGEX)
+    if (!match) return input
 
     // Consume buffer
     const [_, indentation, __, ___, comment] = match
@@ -97,16 +98,16 @@ export const fixLineTooLong = (input: string): string => {
 }
 
 const ensureParantheses = (text: string): string => {
-    const match = text.match(WRAPPABLE_LINE_REGEX);
-    if (!match) return text;
-    const [_, indentation, command, content] = match;
-    return `${indentation}${command} ("${content}")`;
+    const match = text.match(WRAPPABLE_LINE_REGEX)
+    if (!match) return text
+    const [_, indentation, command, content] = match
+    return `${indentation}${command} ("${content}")`
 }
 
 const nextWrap = (result: string, bufferIn: string): [string, string] => {
     if (bufferIn.length <= MAX_LINE_LENGTH) {
         // Remaining text fits in one line. Append it and return empty buffer.
-        return [result + bufferIn, ''];
+        return [result + bufferIn, '']
     }
     const maxLength = MAX_LINE_LENGTH - 3 // Leave 3 for quote continuation
     // Find the last space before max length
@@ -125,11 +126,84 @@ const nextWrap = (result: string, bufferIn: string): [string, string] => {
     }
 
     // Split the buffer
-    const currentLine = bufferIn.substring(0, cutIndex);
-    const remainingBuffer = bufferIn.substring(cutIndex);
+    const currentLine = bufferIn.substring(0, cutIndex)
+    const remainingBuffer = bufferIn.substring(cutIndex)
 
     // Add line continuation marker if there's more text
-    const suffix = remainingBuffer ? QUOTE_CONTINUATION : '';
+    const suffix = remainingBuffer ? QUOTE_CONTINUATION : ''
 
-    return [result + currentLine + suffix, remainingBuffer];
-};
+    return [result + currentLine + suffix, remainingBuffer]
+}
+
+// String constants for block types
+const PUSH = 'push'
+const FASTPUSH = 'fastpush'
+const BLOCK = 'block'
+
+// Core regex patterns for indentation processing
+const BLOCK_START_REGEX = /^(if|ifnot|else_if|else_ifnot|else|loop|when|push|fastpush|push|is|default|:)/i
+const BLOCK_END_REGEX = /^(\.|else_if|else_ifnot|else|fastpop|pop)/i
+const PUSH_REGEX = /^push/i
+const FASTPUSH_REGEX = /^fastpush/i
+const POP_REGEX = /^pop/i
+const FASTPOP_REGEX = /^fastpop/i
+const INDENT_SIZE = 2 // Spaces per indentation level
+
+const indentText = (text: string, indentationCount: number): string =>
+    ' '.repeat(Math.max(0, indentationCount) * INDENT_SIZE) + text
+
+/**
+ * Formats document indentation based on GSL language structure rules.
+ * Handles blocks, control statements, and special push/pop operations.
+ */
+export const formatIndentation = (document: TextDocument): string => {
+    const formattedLines = new Array<string>()
+    const blockStack = new Array<string>()
+
+    for (let i = 0; i < document.lineCount; i++) {
+        const line = document.lineAt(i)
+        const text = line.text.trim()
+        const currentBlock = blockStack.length > 0 ? blockStack[blockStack.length - 1] : null
+
+        // Preserve empty lines
+        if (text === '') {
+            formattedLines.push('')
+            continue
+        }
+
+        // Process unindent
+        if (BLOCK_END_REGEX.test(text) && blockStack.length > 0) {
+            if (POP_REGEX.test(text)) {
+                if (currentBlock === PUSH) {
+                    blockStack.pop()
+                }
+            } else if (FASTPOP_REGEX.test(text)) {
+                if (currentBlock === FASTPUSH) {
+                    blockStack.pop()
+                }
+            } else {
+                blockStack.pop()
+            }
+        }
+
+        // Format line (unless it's a whole-line comment at column 0)
+        if (line.text.startsWith('!')) {
+            formattedLines.push(line.text.trimEnd())
+        } else {
+            formattedLines.push(indentText(text, blockStack.length))
+        }
+
+        // Process indentation increases
+        if (BLOCK_START_REGEX.test(text)) {
+            if (PUSH_REGEX.test(text)) {
+                blockStack.push(PUSH)
+            } else if (FASTPUSH_REGEX.test(text)) {
+                blockStack.push(FASTPUSH)
+            } else {
+                blockStack.push(BLOCK)
+            }
+        }
+    }
+
+    return formattedLines.join('\n')
+}

--- a/gsl/util/typeUtil.ts
+++ b/gsl/util/typeUtil.ts
@@ -25,3 +25,7 @@ export const assertNever = <T> (value: never, fallback: T): T => {
     console.error(`assertNever() called with ${value}`, value)
     return fallback
 }
+
+export const isNonVoid = <T> (value: T): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/parser": "^6.2.0",
         "@vscode/test-electron": "^2.3.3",
         "eslint": "^8.46.0",
+        "glob": "^11.0.1",
         "mocha": "^10.2.0",
         "typescript": "^5.1.6"
       },
@@ -28,30 +29,29 @@
         "vscode": "^1.88.0"
       }
     },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.2",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -59,7 +59,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.1",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -80,8 +82,34 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
-      "version": "8.46.0",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -89,20 +117,49 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -114,12 +171,64 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -132,6 +241,8 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -140,6 +251,8 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -150,39 +263,41 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@types/mocha": {
-      "version": "10.0.1",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.4.5",
+      "version": "20.17.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.25.tgz",
+      "integrity": "sha512-bT+r2haIlplJUYtlZrEanFHdPIZTeiMeh/fSOEbOOfWf9uTn+lg8g0KU6Q3iMgjd9FLuuMAgfCNSkjUbxL6E3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.98.0.tgz",
+      "integrity": "sha512-+KuiWhpbKBaG2egF+51KjbGWatTH5BbmWQjSLMDCssb4xF8FJnW4nGH4nuAdOOfMbpD0QlHtI+C3tPq+DoKElg==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/vscode": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
-      "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.2.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.2.0",
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/typescript-estree": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -202,12 +317,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.2.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0"
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -218,7 +335,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.2.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -230,15 +349,18 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.2.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "6.2.0",
-        "@typescript-eslint/visitor-keys": "6.2.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -256,11 +378,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.2.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/types": "6.21.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -271,22 +395,34 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.3",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
+      "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
         "jszip": "^3.10.1",
-        "semver": "^7.3.8"
+        "ora": "^7.0.1",
+        "semver": "^7.6.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -298,6 +434,8 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -305,18 +443,19 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -331,7 +470,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -340,6 +481,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -348,6 +491,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -362,6 +507,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -374,11 +521,15 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -387,23 +538,78 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
+    "node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -411,6 +617,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -420,11 +627,40 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -433,6 +669,8 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -444,6 +682,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -458,14 +698,10 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -479,12 +715,17 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -494,8 +735,39 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -504,8 +776,50 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -517,21 +831,29 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -544,16 +866,19 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.5.tgz",
-      "integrity": "sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -566,6 +891,8 @@
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -577,11 +904,15 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "5.0.0",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -590,6 +921,8 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -601,6 +934,8 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -610,13 +945,24 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -625,6 +971,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -635,17 +983,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.46.0",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.1",
-        "@eslint/js": "^8.46.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -653,7 +1005,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.2",
+        "eslint-visitor-keys": "^3.4.3",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -689,6 +1041,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -703,7 +1057,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -713,8 +1069,34 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -730,7 +1112,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -742,6 +1126,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -753,6 +1139,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -761,6 +1149,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -769,11 +1159,15 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -781,7 +1175,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -789,6 +1183,8 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -800,16 +1196,22 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -818,6 +1220,8 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -832,6 +1236,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -841,6 +1246,8 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -856,6 +1263,8 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
@@ -863,11 +1272,14 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -875,18 +1287,42 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -898,6 +1334,8 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -905,19 +1343,24 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -925,6 +1368,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -934,8 +1379,26 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
-      "version": "13.20.0",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -950,6 +1413,8 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -969,11 +1434,15 @@
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -982,6 +1451,8 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -989,32 +1460,58 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1023,11 +1520,15 @@
     },
     "node_modules/immediate": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1043,6 +1544,8 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1051,6 +1554,9 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1060,11 +1566,15 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1076,6 +1586,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1084,6 +1596,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1092,6 +1606,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1101,17 +1617,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1120,6 +1652,8 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1128,6 +1662,8 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1139,16 +1675,38 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1158,18 +1716,31 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
@@ -1179,8 +1750,20 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1193,6 +1776,8 @@
     },
     "node_modules/lie": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1201,6 +1786,8 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1215,11 +1802,15 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1234,17 +1825,19 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1252,54 +1845,82 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
-      "version": "10.2.0",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
@@ -1307,22 +1928,33 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1332,13 +1964,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1352,28 +1981,23 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1382,30 +2006,173 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.9.3",
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
+      "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.9.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.3.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "string-width": "^6.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
+      "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^10.2.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1420,6 +2187,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1432,13 +2201,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1450,6 +2230,8 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1458,6 +2240,8 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1466,14 +2250,35 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1482,6 +2287,8 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1493,6 +2300,8 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1501,11 +2310,15 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1514,6 +2327,8 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -1533,6 +2348,8 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1541,6 +2358,8 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1555,6 +2374,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1566,6 +2387,8 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1574,14 +2397,42 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/reusify": {
-      "version": "1.0.4",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1591,6 +2442,9 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1603,8 +2457,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -1627,15 +2529,16 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1644,7 +2547,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1653,11 +2558,15 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1669,22 +2578,57 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
+      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1692,7 +2636,28 @@
       }
     },
     "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1704,8 +2669,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1717,6 +2734,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1728,6 +2747,8 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1739,6 +2760,8 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1747,6 +2770,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1755,11 +2779,13 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.1",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
@@ -1767,6 +2793,8 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1778,6 +2806,8 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -1788,7 +2818,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1799,8 +2831,17 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1809,11 +2850,15 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -1821,6 +2866,8 @@
     },
     "node_modules/vscode-languageclient": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^5.1.0",
@@ -1831,15 +2878,10 @@
         "vscode": "^1.67.0"
       }
     },
-    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/vscode-languageclient/node_modules/minimatch": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1850,6 +2892,8 @@
     },
     "node_modules/vscode-languageserver": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.17.3"
@@ -1860,6 +2904,8 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
       "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "8.1.0",
@@ -1868,10 +2914,14 @@
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
       "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1884,13 +2934,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/workerpool": {
-      "version": "6.2.1",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1905,25 +2988,91 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1940,7 +3089,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1949,6 +3100,8 @@
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1961,8 +3114,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
         "command": "gsl.formatIndentation",
         "title": "Format Document Indentation",
         "category": "GSL"
+      },
+      {
+        "command": "gsl.alignComments",
+        "title": "Align Document Comments",
+        "category": "GSL"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
         "command": "gsl.openConnection",
         "title": "Open Development Server Connection",
         "category": "GSL"
+      },
+      {
+        "command": "gsl.formatIndentation",
+        "title": "Format Document Indentation",
+        "category": "GSL"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/parser": "^6.2.0",
     "@vscode/test-electron": "^2.3.3",
     "eslint": "^8.46.0",
+    "glob": "^11.0.1",
     "mocha": "^10.2.0",
     "typescript": "^5.1.6"
   },
@@ -46,7 +47,8 @@
     "vscode:prepublish": "npm run compile && cd gsl-language-server && npm run compile",
     "postinstall": "cd gsl-language-server && npm ci && cd ..",
     "compile": "tsc -b",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "node test/runTests.js"
   },
   "main": "extension",
   "contributes": {

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -3,8 +3,36 @@ import { runTests } from '@vscode/test-electron'
 
 async function main() {
     try {
+        // Parse command line arguments to separate file and test filters
+        const args = process.argv.slice(2)
+        const fileFilters = []
+        const testFilters = []
+
+        // Process args to separate file and test filters
+        for (let i = 0; i < args.length; i++) {
+            if (args[i] === '--file-match' && i + 1 < args.length) {
+                fileFilters.push(args[++i])
+            } else if (args[i] === '--test-match' && i + 1 < args.length) {
+                testFilters.push(args[++i])
+            } else if (!args[i].startsWith('--')) {
+                // Default to file filter if no flag is specified
+                fileFilters.push(args[i])
+            }
+        }
+
         const extensionDevelopmentPath = path.resolve(__dirname, '..')
         const extensionTestsPath = path.resolve(__dirname, './suite/index.js')
+
+        // Set environment variables for test filters
+        if (fileFilters.length > 0) {
+            process.env.FILE_FILTERS = JSON.stringify(fileFilters)
+            console.log(`File filters: ${fileFilters.join(', ')}`)
+        }
+
+        if (testFilters.length > 0) {
+            process.env.TEST_FILTERS = JSON.stringify(testFilters)
+            console.log(`Test filters: ${testFilters.join(', ')}`)
+        }
 
         await runTests({
             extensionDevelopmentPath,

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -1,0 +1,18 @@
+import * as path from 'path'
+import { runTests } from '@vscode/test-electron'
+
+async function main() {
+    try {
+        const extensionDevelopmentPath = path.resolve(__dirname, '..')
+        const extensionTestsPath = path.resolve(__dirname, './suite/index.js')
+
+        await runTests({
+            extensionDevelopmentPath,
+            extensionTestsPath
+        })
+    } catch (err) {
+        console.error('Failed to run tests:', err)
+        process.exit(1)
+    }
+}
+main()

--- a/test/suite/codeActionProvider.test.ts
+++ b/test/suite/codeActionProvider.test.ts
@@ -1,0 +1,165 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { GSLCodeActionProvider } from '../../gsl/codeActionProvider'
+import { LINE_TOO_LONG } from '../../gsl/diagnostics'
+import { QUOTE_CONTINUATION } from '../../gsl/util/formattingUtil'
+
+const buildDiagnostic = (range: vscode.Range): vscode.Diagnostic => ({
+    code: LINE_TOO_LONG,
+    range,
+    message: 'Line is too long',
+    severity: vscode.DiagnosticSeverity.Warning
+})
+
+suite('GSLCodeActionProvider Test Suite', () => {
+    let document: vscode.TextDocument
+    let provider: GSLCodeActionProvider
+
+    // Helper to run provider and return the replacement text from the WorkspaceEdit.
+    async function getReplacementText(content: string): Promise<string> {
+        // Open a new document with provided content.
+        document = await vscode.workspace.openTextDocument({
+            language: 'gsl',
+            content
+        })
+        provider = new GSLCodeActionProvider()
+        // Create a range that covers the entire line
+        const range = new vscode.Range(0, 0, 0, content.length)
+        const context: vscode.CodeActionContext = {
+            diagnostics: [buildDiagnostic(range)],
+            triggerKind: vscode.CodeActionTriggerKind.Invoke,
+            only: undefined
+        }
+        const actions = await Promise.resolve(provider.provideCodeActions(document, range, context))
+        assert.strictEqual(actions?.length, 1, 'Expected one code action')
+        const edit = (actions[0] as vscode.CodeAction).edit
+        assert.ok(edit, 'Expected WorkspaceEdit to be defined')
+        const edits = edit.get(document.uri)
+        assert.ok(edits && edits.length > 0, 'Expected at least one TextEdit in WorkspaceEdit')
+        return edits[0].newText
+    }
+
+    test('should offer wrap action for long set command', async () => {
+        const longText = 'set T9 to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `set T9 to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds${QUOTE_CONTINUATION}` +
+            `" elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis${QUOTE_CONTINUATION}` +
+            `" sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit${QUOTE_CONTINUATION}` +
+            `" scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for long set command (with table)', async () => {
+        const longText = 'set table:12345[3,2,4] to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `set table:12345[3,2,4] to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus${QUOTE_CONTINUATION}` +
+            `" fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna,${QUOTE_CONTINUATION}` +
+            `" eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu${QUOTE_CONTINUATION}` +
+            `" blandit scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for msg command', async () => {
+        const longText = 'msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
+            `" ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien${QUOTE_CONTINUATION}` +
+            `" nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for msg command, adding parantheses', async () => {
+        const longText = 'msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
+            `" ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien${QUOTE_CONTINUATION}` +
+            `" nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for msgp command, adding parantheses', async () => {
+        const longText = 'msgp "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `msgp ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac${QUOTE_CONTINUATION}` +
+            `" nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla${QUOTE_CONTINUATION}` +
+            `" ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for msgr command, adding parantheses', async () => {
+        const longText = 'msgr "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `msgr ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac${QUOTE_CONTINUATION}` +
+            `" nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla${QUOTE_CONTINUATION}` +
+            `" ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for msgrxp command, adding parantheses', async () => {
+        const longText = 'msgrxp "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `msgrxp ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
+            `" ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien${QUOTE_CONTINUATION}` +
+            `" nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")`
+        )
+    })
+
+    test('should offer wrap action for msgrx2 command, adding parantheses', async () => {
+        const longText = 'msgrx2 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `msgrx2 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
+            `" ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien${QUOTE_CONTINUATION}` +
+            `" nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")`
+        )
+    })
+
+    test('should handle indentation', async () => {
+        const longText = '    msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
+            `    " elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu${QUOTE_CONTINUATION}` +
+            `    " facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu${QUOTE_CONTINUATION}` +
+            `    " blandit scelerisque.")`
+        )
+    })
+
+    test('should handle comments', async () => {
+        const longText = '    msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque." ! foobar biz baz'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
+            `    " elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu${QUOTE_CONTINUATION}` +
+            `    " facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu${QUOTE_CONTINUATION}` +
+            `    " blandit scelerisque.")\n    ! foobar biz baz`
+        )
+    })
+
+    test('should handle a long unbroken string', async () => {
+        const longText = '  msgp ("testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestintestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestinFoobarfoo")'
+        const replacement = await getReplacementText(longText)
+        assert.equal(
+            replacement,
+            `  msgp ("testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestintestingt${QUOTE_CONTINUATION}` +
+            `  "estingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestinFoobarfoo")`
+        )
+    })
+})

--- a/test/suite/codeActionProvider.test.ts
+++ b/test/suite/codeActionProvider.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as vscode from 'vscode'
-import { GSLCodeActionProvider } from '../../gsl/codeActionProvider'
+import { GSLCodeActionProvider, ACTION_WRAP_TO_MULTIPLE, ACTION_COLLAPSE_MULTILINE, ACTION_REDISTRIBUTE_MULTILINE } from '../../gsl/codeActionProvider'
 import { LINE_TOO_LONG } from '../../gsl/diagnostics'
 import { QUOTE_CONTINUATION } from '../../gsl/util/formattingUtil'
 
@@ -16,7 +16,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
     let provider: GSLCodeActionProvider
 
     // Helper to run provider and return the replacement text from the WorkspaceEdit.
-    async function getReplacementText(content: string): Promise<string> {
+    async function getReplacementText(content: string, actionTitle: string): Promise<string> {
         // Open a new document with provided content.
         document = await vscode.workspace.openTextDocument({
             language: 'gsl',
@@ -31,8 +31,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
             only: undefined
         }
         const actions = await Promise.resolve(provider.provideCodeActions(document, range, context))
-        assert.strictEqual(actions?.length, 1, 'Expected one code action')
-        const edit = (actions[0] as vscode.CodeAction).edit
+        const action = actions?.find(a => a.title === actionTitle)
+        assert.ok(action, `Expected to find action with title "${actionTitle}"`)
+        const edit = action.edit
         assert.ok(edit, 'Expected WorkspaceEdit to be defined')
         const edits = edit.get(document.uri)
         assert.ok(edits && edits.length > 0, 'Expected at least one TextEdit in WorkspaceEdit')
@@ -41,7 +42,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for long set command', async () => {
         const longText = 'set T9 to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `set T9 to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds${QUOTE_CONTINUATION}` +
@@ -53,7 +54,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for long set command (with table)', async () => {
         const longText = 'set table:12345[3,2,4] to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `set table:12345[3,2,4] to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus${QUOTE_CONTINUATION}` +
@@ -65,7 +66,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msg command', async () => {
         const longText = 'msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -76,7 +77,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msg command, adding parantheses', async () => {
         const longText = 'msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -87,7 +88,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgp command, adding parantheses', async () => {
         const longText = 'msgp "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgp ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac${QUOTE_CONTINUATION}` +
@@ -98,7 +99,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgr command, adding parantheses', async () => {
         const longText = 'msgr "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgr ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac${QUOTE_CONTINUATION}` +
@@ -109,7 +110,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgrxp command, adding parantheses', async () => {
         const longText = 'msgrxp "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgrxp ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -120,7 +121,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgrx2 command, adding parantheses', async () => {
         const longText = 'msgrx2 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgrx2 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -131,7 +132,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should handle indentation', async () => {
         const longText = '    msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
@@ -143,7 +144,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should handle comments', async () => {
         const longText = '    msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque." ! foobar biz baz'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
@@ -155,11 +156,57 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should handle a long unbroken string', async () => {
         const longText = '  msgp ("testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestintestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestinFoobarfoo")'
-        const replacement = await getReplacementText(longText)
+        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `  msgp ("testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestintestingt${QUOTE_CONTINUATION}` +
             `  "estingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestinFoobarfoo")`
+        )
+    })
+
+    test('should collapse multiline string', async () => {
+        const multiLineString = 
+            `msgp ("This is a test" +\\
+            " that spans multiple" +\\
+            " lines")`
+        assert.equal(
+            await getReplacementText(multiLineString, ACTION_COLLAPSE_MULTILINE),
+            'msgp "This is a test that spans multiple lines"'
+        )
+    })
+
+    test('should collapse multiline string with indentation', async () => {
+        const multiLineString = 
+            `    msgp ("This is a test" +\\
+            " that spans multiple" +\\
+            " lines")`
+        assert.equal(
+            await getReplacementText(multiLineString, ACTION_COLLAPSE_MULTILINE),
+            '    msgp "This is a test that spans multiple lines"'
+        )
+    })
+
+    test('should redistribute multiline string to one line if possible, removing parantheses', async () => {
+        const multiLineString = 
+            `    msgp ("This is a test" +\\
+            " that spans multiple" +\\
+            " lines")`
+        assert.equal(
+            await getReplacementText(multiLineString, ACTION_REDISTRIBUTE_MULTILINE),
+            '    msgp "This is a test that spans multiple lines"'
+        )
+    })
+
+    test('should redistribute multiline string to shortest number of lines if one line is not possible', async () => {
+        const multiLineString = 
+        `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
+        `    " elementum , eu${QUOTE_CONTINUATION}` +
+        `    " facilisis Praesent dapibus est eu${QUOTE_CONTINUATION}` +
+        `    " blandit scelerisque.")`
+        assert.equal(
+            await getReplacementText(multiLineString, ACTION_REDISTRIBUTE_MULTILINE),
+            `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
+            `    " elementum , eu facilisis Praesent dapibus est eu blandit scelerisque.")`
         )
     })
 })

--- a/test/suite/codeActionProvider.test.ts
+++ b/test/suite/codeActionProvider.test.ts
@@ -297,9 +297,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 `msgr "Bar biz baz rawr" ! Bar\n`,
                 ACTION_ALIGN_COMMENTS
             ),
-            'msgr "a"                                                    ! A\n' +
-            'msgp "Foo"                                                  ! Foo\n' +
-            'msgr "Bar biz baz rawr"                                     ! Bar\n'
+            'msgr "a"                                                       ! A\n' +
+            'msgp "Foo"                                                     ! Foo\n' +
+            'msgr "Bar biz baz rawr"                                        ! Bar\n'
         )
     })
 
@@ -311,9 +311,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 `  msgr "FooBar" ! FooBar\n`,
                 ACTION_ALIGN_COMMENTS
             ),
-            '  msgp "a"                                                  ! A\n' +
+            '  msgp "a"                                                     ! A\n' +
             '  ! This is a whole line comment\n' +
-            '  msgr "FooBar"                                             ! FooBar\n'
+            '  msgr "FooBar"                                                ! FooBar\n'
         )
     })
 
@@ -325,9 +325,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 `msgr "Bar biz baz rawr"                                    ! Bar\n`,
                 ACTION_ALIGN_COMMENTS
             ),
-            'msgr "a"                                                    ! A\n' +
-            'msgp "Foo"                                                  ! Foo\n' +
-            'msgr "Bar biz baz rawr"                                     ! Bar\n'
+            'msgr "a"                                                       ! A\n' +
+            'msgp "Foo"                                                     ! Foo\n' +
+            'msgr "Bar biz baz rawr"                                        ! Bar\n'
         )
     })
 
@@ -338,8 +338,8 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 '  msgr "b"                                                                               ! B\n',
                 ACTION_ALIGN_COMMENTS
             ),
-            '  msgp "a"             ! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus\n' +
-            '  msgr "b"                                                  ! B\n'
+            '  msgp "a" ! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus\n' +
+            '  msgr "b"                                                     ! B\n'
         )
     })
 
@@ -351,9 +351,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 `msgr "Bar biz baz rawr" ! Bar\n`,
                 ACTION_ALIGN_COMMENTS
             ),
-            'msgr "a"                                                    ! A\n' +
-            'msgp "Foo!"                                                 ! Foo\n' +
-            'msgr "Bar biz baz rawr"                                     ! Bar\n'
+            'msgr "a"                                                       ! A\n' +
+            'msgp "Foo!"                                                    ! Foo\n' +
+            'msgr "Bar biz baz rawr"                                        ! Bar\n'
         )
     })
 
@@ -368,10 +368,44 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 ACTION_ALIGN_COMMENTS
             ),
             `if (A1 != A2) then\n` +
-            '  msgr "a"                                                  ! A\n' +
-            '  msgp "Foo!"                                               ! Foo\n' +
-            '  msgr "Bar biz baz rawr"                                   ! Bar\n' +
+            '  msgr "a"                                                     ! A\n' +
+            '  msgp "Foo!"                                                  ! Foo\n' +
+            '  msgr "Bar biz baz rawr"                                      ! Bar\n' +
             '.\n'
+        )
+    })
+
+    test('should ignore exclamation points in parantheses - 2nd case', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `  if ((NR0 / 1000) != 3031) then\n` +
+                `      stop                                                    ! Failure, not in Nelemar\n` +
+                `  .\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            `  if ((NR0 / 1000) != 3031) then\n` +
+            `      stop                                                     ! Failure, not in Nelemar\n` +
+            `  .\n`
+        )
+    })
+
+    test('should skip multiline segments', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `msgp "foo" ! a\n` +
+                `if ( \\ ! b\n` +
+                `  (NR0 / 1000) != 3031 \\ ! c\n` +
+                `) then ! d\n` +
+                `    stop ! e\n` +
+                `.! f\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            `msgp "foo"                                                     ! a\n` +
+            `if ( \\ ! b\n` +
+            `  (NR0 / 1000) != 3031 \\ ! c\n` +
+            `) then                                                         ! d\n` +
+            `    stop                                                       ! e\n` +
+            `.                                                              ! f\n`,
         )
     })
 })

--- a/test/suite/codeActionProvider.test.ts
+++ b/test/suite/codeActionProvider.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as vscode from 'vscode'
-import { GSLCodeActionProvider, ACTION_WRAP_TO_MULTIPLE, ACTION_COLLAPSE_MULTILINE, ACTION_REDISTRIBUTE_MULTILINE, COMBINE_MULTIPLE_MESSAGES } from '../../gsl/codeActionProvider'
+import { GSLCodeActionProvider, ACTION_WRAP_TO_MULTIPLE, ACTION_COLLAPSE_MULTILINE, ACTION_REDISTRIBUTE_MULTILINE, COMBINE_MULTIPLE_MESSAGES, ACTION_ALIGN_COMMENTS } from '../../gsl/codeActionProvider'
 import { LINE_TOO_LONG } from '../../gsl/diagnostics'
 import { QUOTE_CONTINUATION } from '../../gsl/util/formattingUtil'
 
@@ -15,8 +15,16 @@ suite('GSLCodeActionProvider Test Suite', () => {
     let document: vscode.TextDocument
     let provider: GSLCodeActionProvider
 
-    // Helper to run provider and return the replacement text from the WorkspaceEdit.
-    async function getReplacementText(content: string, actionTitle: string): Promise<string> {
+    /**
+     * Finds the first Code Action applicable to the given `content` in the given
+     * `range`, applies it to `content`, and returns the result. Asserts that at
+     * least one Code Action of `actionTitle` is found. 
+     */
+    async function applyCodeAction(
+        content: string,
+        actionTitle: string,
+        range: vscode.Range = new vscode.Range(0, 0, 0, content.length)
+    ): Promise<string> {
         // Open a new document with provided content.
         document = await vscode.workspace.openTextDocument({
             language: 'gsl',
@@ -24,7 +32,6 @@ suite('GSLCodeActionProvider Test Suite', () => {
         })
         provider = new GSLCodeActionProvider()
         // Create a range that covers the entire line
-        const range = new vscode.Range(0, 0, 0, content.length)
         const context: vscode.CodeActionContext = {
             diagnostics: [buildDiagnostic(range)],
             triggerKind: vscode.CodeActionTriggerKind.Invoke,
@@ -37,12 +44,38 @@ suite('GSLCodeActionProvider Test Suite', () => {
         assert.ok(edit, 'Expected WorkspaceEdit to be defined')
         const edits = edit.get(document.uri)
         assert.ok(edits && edits.length > 0, 'Expected at least one TextEdit in WorkspaceEdit')
-        return edits[0].newText
+
+        // Sort edits in reverse order to apply from bottom to top
+        edits.sort((a, b) => b.range.start.compareTo(a.range.start))
+
+        // Apply all edits to the content
+        let result = content
+        for (const edit of edits) {
+            const startOffset = document.offsetAt(edit.range.start)
+            const endOffset = document.offsetAt(edit.range.end)
+            result = result.substring(0, startOffset) + edit.newText + result.substring(endOffset)
+        }
+        return result
+    }
+
+    /**
+     * Same as `applyCodeAction`, but presumes that the user has all of `content` selected.
+     */
+    async function applyCodeActionToSelection(
+        content: string,
+        actionTitle: string
+    ): Promise<string> {
+        const lineCount = content.split("\n").length
+        return applyCodeAction(
+            content,
+            actionTitle,
+            new vscode.Range(0, 0, lineCount - 1, content.length)
+        )
     }
 
     test('should offer wrap action for long set command', async () => {
         const longText = 'set T9 to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `set T9 to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds${QUOTE_CONTINUATION}` +
@@ -54,7 +87,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for long set command (with table)', async () => {
         const longText = 'set table:12345[3,2,4] to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus fidddsibudds elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `set table:12345[3,2,4] to ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus${QUOTE_CONTINUATION}` +
@@ -66,7 +99,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msg command', async () => {
         const longText = 'msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque.")'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -77,7 +110,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msg command, adding parantheses', async () => {
         const longText = 'msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -88,7 +121,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgp command, adding parantheses', async () => {
         const longText = 'msgp "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgp ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac${QUOTE_CONTINUATION}` +
@@ -99,7 +132,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgr command, adding parantheses', async () => {
         const longText = 'msgr "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgr ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac${QUOTE_CONTINUATION}` +
@@ -110,7 +143,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgrxp command, adding parantheses', async () => {
         const longText = 'msgrxp "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgrxp ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -121,7 +154,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should offer wrap action for msgrx2 command, adding parantheses', async () => {
         const longText = 'msgrx2 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `msgrx2 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum${QUOTE_CONTINUATION}` +
@@ -132,7 +165,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should handle indentation', async () => {
         const longText = '    msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque."'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
@@ -144,7 +177,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should handle comments', async () => {
         const longText = '    msg NP1 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus elementum ac nec ligula. Proin hendrerit, lorem in sagittis consequat, metus massa aliquet magna, eu facilisis sapien nulla ut eros. Etiam facilisis eros ut ligula consequat malesuada. Praesent dapibus est eu blandit scelerisque." ! foobar biz baz'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
@@ -156,7 +189,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
 
     test('should handle a long unbroken string', async () => {
         const longText = '  msgp ("testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestintestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestinFoobarfoo")'
-        const replacement = await getReplacementText(longText, ACTION_WRAP_TO_MULTIPLE)
+        const replacement = await applyCodeAction(longText, ACTION_WRAP_TO_MULTIPLE)
         assert.equal(
             replacement,
             `  msgp ("testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestintestingt${QUOTE_CONTINUATION}` +
@@ -170,7 +203,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
             " that spans multiple" +\\
             " lines")`
         assert.equal(
-            await getReplacementText(multiLineString, ACTION_COLLAPSE_MULTILINE),
+            await applyCodeAction(multiLineString, ACTION_COLLAPSE_MULTILINE),
             'msgp "This is a test that spans multiple lines"'
         )
     })
@@ -181,7 +214,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
             " that spans multiple" +\\
             " lines")`
         assert.equal(
-            await getReplacementText(multiLineString, ACTION_COLLAPSE_MULTILINE),
+            await applyCodeAction(multiLineString, ACTION_COLLAPSE_MULTILINE),
             '    msgp "This is a test that spans multiple lines"'
         )
     })
@@ -192,7 +225,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
             " that spans multiple" +\\
             " lines")`
         assert.equal(
-            await getReplacementText(multiLineString, ACTION_REDISTRIBUTE_MULTILINE),
+            await applyCodeAction(multiLineString, ACTION_REDISTRIBUTE_MULTILINE),
             '    msgp "This is a test that spans multiple lines"'
         )
     })
@@ -204,7 +237,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
             `    " facilisis Praesent dapibus est eu${QUOTE_CONTINUATION}` +
             `    " blandit scelerisque.")`
         assert.equal(
-            await getReplacementText(multiLineString, ACTION_REDISTRIBUTE_MULTILINE),
+            await applyCodeAction(multiLineString, ACTION_REDISTRIBUTE_MULTILINE),
             `    msg NP1 ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus${QUOTE_CONTINUATION}` +
             `    " elementum , eu facilisis Praesent dapibus est eu blandit scelerisque.")`
         )
@@ -215,7 +248,7 @@ suite('GSLCodeActionProvider Test Suite', () => {
             `    msgp "Foo$\\"\n` +
             `    msgp "Bar"`
         assert.equal(
-            await getReplacementText(multiLineString, COMBINE_MULTIPLE_MESSAGES),
+            await applyCodeAction(multiLineString, COMBINE_MULTIPLE_MESSAGES),
             `    msgp "FooBar"`
         )
     })
@@ -226,8 +259,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
             `    msgp "Bar$\\"\n` +
             `    msgr "Baz"`
         assert.equal(
-            await getReplacementText(multiLineString, COMBINE_MULTIPLE_MESSAGES),
-            `    msgp "FooBar$\\"`
+            await applyCodeAction(multiLineString, COMBINE_MULTIPLE_MESSAGES),
+            `    msgp "FooBar$\\"\n` +
+            `    msgr "Baz"`
         )
     })
 
@@ -237,8 +271,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
             `    msg NP0 "Bar$\\"\n` +
             `    msg NP1 "Baz$\\"\n`
         assert.equal(
-            await getReplacementText(multiLineString, COMBINE_MULTIPLE_MESSAGES),
-            `    msg NP0 "FooBar$\\"`
+            await applyCodeAction(multiLineString, COMBINE_MULTIPLE_MESSAGES),
+            `    msg NP0 "FooBar$\\"\n` +
+            `    msg NP1 "Baz$\\"\n`
         )
     })
 
@@ -247,10 +282,50 @@ suite('GSLCodeActionProvider Test Suite', () => {
             `    msg NP0 "Foo$\\" ! Comment1\n` +
             `    msg NP0 "Bar" ! Comment2\n`
         assert.equal(
-            await getReplacementText(multiLineString, COMBINE_MULTIPLE_MESSAGES),
+            await applyCodeAction(multiLineString, COMBINE_MULTIPLE_MESSAGES),
             `    msg NP0 "FooBar"\n` +
             `    ! Comment1\n` +
-            `    ! Comment2`
+            `    ! Comment2\n`
+        )
+    })
+
+    test('should align comments', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `msgr "a" ! A\n` +
+                `msgp "Foo" ! Foo\n` +
+                `msgr "Bar biz baz rawr" ! Bar\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            'msgr "a"                ! A\n' +
+            'msgp "Foo"              ! Foo\n' +
+            'msgr "Bar biz baz rawr" ! Bar\n'
+        )
+    })
+
+    test('should not align whole-line comments', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `  msgp "a" ! A\n` +
+                `  ! This is a whole line comment\n` +
+                `  msgr "FooBar" ! FooBar\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            '  msgp "a"      ! A\n' +
+            '  ! This is a whole line comment\n' +
+            '  msgr "FooBar" ! FooBar\n'
+        )
+    })
+
+    test('should respect the 120 character limit', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                '  msgp "a"      ! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus\n' +
+                '  msgr "b"                                                                               ! B\n',
+                ACTION_ALIGN_COMMENTS
+            ),
+            '  msgp "a"             ! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus\n' +
+            '  msgr "b"                                                                               ! B\n'
         )
     })
 })

--- a/test/suite/codeActionProvider.test.ts
+++ b/test/suite/codeActionProvider.test.ts
@@ -297,9 +297,9 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 `msgr "Bar biz baz rawr" ! Bar\n`,
                 ACTION_ALIGN_COMMENTS
             ),
-            'msgr "a"                ! A\n' +
-            'msgp "Foo"              ! Foo\n' +
-            'msgr "Bar biz baz rawr" ! Bar\n'
+            'msgr "a"                                                    ! A\n' +
+            'msgp "Foo"                                                  ! Foo\n' +
+            'msgr "Bar biz baz rawr"                                     ! Bar\n'
         )
     })
 
@@ -311,9 +311,23 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 `  msgr "FooBar" ! FooBar\n`,
                 ACTION_ALIGN_COMMENTS
             ),
-            '  msgp "a"      ! A\n' +
+            '  msgp "a"                                                  ! A\n' +
             '  ! This is a whole line comment\n' +
-            '  msgr "FooBar" ! FooBar\n'
+            '  msgr "FooBar"                                             ! FooBar\n'
+        )
+    })
+
+    test('should align comments leftwards if comments are unnecessarily deeply indented', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `msgr "a"                                     ! A\n` +
+                `msgp "Foo"                                           ! Foo\n` +
+                `msgr "Bar biz baz rawr"                                    ! Bar\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            'msgr "a"                                                    ! A\n' +
+            'msgp "Foo"                                                  ! Foo\n' +
+            'msgr "Bar biz baz rawr"                                     ! Bar\n'
         )
     })
 
@@ -325,7 +339,39 @@ suite('GSLCodeActionProvider Test Suite', () => {
                 ACTION_ALIGN_COMMENTS
             ),
             '  msgp "a"             ! Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam eget turpis nec lacus finibus\n' +
-            '  msgr "b"                                                                               ! B\n'
+            '  msgr "b"                                                  ! B\n'
+        )
+    })
+
+    test('should ignore exclamation points in strings', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `msgr "a" ! A\n` +
+                `msgp "Foo!" ! Foo\n` +
+                `msgr "Bar biz baz rawr" ! Bar\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            'msgr "a"                                                    ! A\n' +
+            'msgp "Foo!"                                                 ! Foo\n' +
+            'msgr "Bar biz baz rawr"                                     ! Bar\n'
+        )
+    })
+
+    test('should ignore exclamation points in parantheses', async () => {
+        assert.equal(
+            await applyCodeActionToSelection(
+                `if (A1 != A2) then\n` +
+                `  msgr "a" ! A\n` +
+                `  msgp "Foo!" ! Foo\n` +
+                `  msgr "Bar biz baz rawr" ! Bar\n` +
+                `.\n`,
+                ACTION_ALIGN_COMMENTS
+            ),
+            `if (A1 != A2) then\n` +
+            '  msgr "a"                                                  ! A\n' +
+            '  msgp "Foo!"                                               ! Foo\n' +
+            '  msgr "Bar biz baz rawr"                                   ! Bar\n' +
+            '.\n'
         )
     })
 })

--- a/test/suite/highlightProvider.test.ts
+++ b/test/suite/highlightProvider.test.ts
@@ -1,0 +1,681 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { GSLDocumentHighlightProvider } from '../../gsl/highlightProvider'
+
+suite('Highlight Provider Test Suite', () => {
+    const provider = new GSLDocumentHighlightProvider()
+
+    /**
+     * Compares input with expected output. Expects a `|` character to be in the input,
+     * indicating the user's cursor location. Output will contain `----` characters to
+     * indicate the ranges highlighted by vscode.
+     */
+    async function testHighlights(input: string, expectedOutput: string): Promise<void> {
+        // Find cursor position marked with | and remove it
+        const lines = input.split('\n')
+        let cursorLine = 0
+        let cursorChar = 0
+        let cleanedInput = ''
+
+        for (let i = 0; i < lines.length; i++) {
+            const pipeIndex = lines[i].indexOf('|')
+            if (pipeIndex >= 0) {
+                cursorLine = i
+                cursorChar = pipeIndex
+                lines[i] = lines[i].substring(0, pipeIndex) + lines[i].substring(pipeIndex + 1)
+            }
+
+            if (i > 0) cleanedInput += '\n'
+            cleanedInput += lines[i]
+        }
+
+        const document = await vscode.workspace.openTextDocument({
+            language: 'gsl',
+            content: cleanedInput
+        })
+
+        const position = new vscode.Position(cursorLine, cursorChar)
+        const highlights = await provider.provideDocumentHighlights(document, position)
+
+        assert.ok(highlights, 'Highlights should not be undefined')
+
+        // Create a marked string from the input based on the actual highlights
+        const resultLines = cleanedInput.split('\n')
+        const markedLines: string[] = []
+
+        // Process each line
+        for (let i = 0; i < resultLines.length; i++) {
+            let line = resultLines[i]
+
+            // Get all highlights for this line and sort them from right to left
+            // to avoid messing up character positions when adding markers
+            const lineHighlights = highlights
+                .filter(h => h.range.start.line === i)
+                .sort((a, b) => b.range.start.character - a.range.start.character)
+
+            // Track already processed character positions to avoid duplicate highlighting
+            const processedRanges: [number, number][] = []
+
+            // Process each highlight for this line
+            for (const highlight of lineHighlights) {
+                const start = highlight.range.start.character
+                const end = highlight.range.end.character
+
+                // Skip if this range overlaps with an already processed range
+                if (processedRanges.some(([s, e]) =>
+                    (start >= s && start < e) || (end > s && end <= e) || (start <= s && end >= e))) {
+                    continue
+                }
+
+                // Add this range to processed ranges
+                processedRanges.push([start, end])
+
+                // Add highlight markers
+                const text = document.getText(highlight.range)
+                line =
+                    line.substring(0, start) +
+                    '----' + text + '----' +
+                    line.substring(end)
+            }
+
+            markedLines.push(line)
+        }
+
+        const actual = markedLines.join('\n')
+
+        // Compare with expected
+        assert.strictEqual(actual, expectedOutput)
+    }
+
+    test('Should highlight standalone word', async () => {
+        await testHighlights(
+            `ms|gp "hello world"\n`,
+            // Expects:
+            `----msgp---- "hello world"\n`
+        )
+    })
+
+    test('Should highlight matching push/pop', async () => {
+        await testHighlights(
+            `p|ush\n` +
+            `  msgp "inside push"\n` +
+            `pop\n`,
+            // Expects:
+            `----push----\n` +
+            `  msgp "inside push"\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should highlight matching push/pop (reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  msgp "inside push"\n` +
+            `p|op\n`,
+            // Expects:
+            `----push----\n` +
+            `  msgp "inside push"\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should highlight matching fastpush/fastpop', async () => {
+        await testHighlights(
+            `|fastpush\n` +
+            `  msgp "inside fastpush"\n` +
+            `fastpop\n`,
+            // Expects:
+            `----fastpush----\n` +
+            `  msgp "inside fastpush"\n` +
+            `----fastpop----\n`
+        )
+    })
+
+    test('Should highlight matching fastpush/fastpop (reverse)', async () => {
+        await testHighlights(
+            `fastpush\n` +
+            `  msgp "inside fastpush"\n` +
+            `|fastpop\n`,
+            // Expects:
+            `----fastpush----\n` +
+            `  msgp "inside fastpush"\n` +
+            `----fastpop----\n`
+        )
+    })
+
+    test('Should highlight matching fastpush/fastpop (reverse)', async () => {
+        await testHighlights(
+            `fastpush\n` +
+            `  msgp "inside fastpush"\n` +
+            `|fastpop\n`,
+            // Expects:
+            `----fastpush----\n` +
+            `  msgp "inside fastpush"\n` +
+            `----fastpop----\n`
+        )
+    })
+
+
+    test('Should highlight matching block start/end', async () => {
+        await testHighlights(
+            `|if A8 then\n` +
+            `  msgp "then branch"\n` +
+            `.\n`,
+            // Expects:
+            `----if---- A8 ----then----\n` +
+            `  msgp "then branch"\n` +
+            `----.----\n`
+        )
+    })
+
+    test('Should highlight matching block start/end (reverse)', async () => {
+        await testHighlights(
+            `if A8 then\n` +
+            `  msgp "then branch"\n` +
+            `.|\n`,
+            // Expects:
+            `----if---- A8 ----then----\n` +
+            `  msgp "then branch"\n` +
+            `----.----\n`
+        )
+    })
+
+    test('Should highlight nested blocks correctly', async () => {
+        await testHighlights(
+            `if A8 then\n` +
+            `  |if B9 then\n` +
+            `    msgp "nested"\n` +
+            `  .\n` +
+            `.\n`,
+            // Expects:
+            `if A8 then\n` +
+            `  ----if---- B9 ----then----\n` +
+            `    msgp "nested"\n` +
+            `  ----.----\n` +
+            `.\n`
+        )
+    })
+
+    test('Should highlight nested blocks correctly (reverse)', async () => {
+        await testHighlights(
+            `if A8 then\n` +
+            `  if B9 then\n` +
+            `    msgp "nested"\n` +
+            `  .|\n` +
+            `.\n`,
+            // Expects:
+            `if A8 then\n` +
+            `  ----if---- B9 ----then----\n` +
+            `    msgp "nested"\n` +
+            `  ----.----\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle early fastpop stop', async () => {
+        await testHighlights(
+            `|fastpush\n` +
+            `  if B9 then\n` +
+            `    fastpop\n` +
+            `    stop\n` +
+            `  .\n` +
+            `fastpop\n`,
+            // Expects:
+            `----fastpush----\n` +
+            `  if B9 then\n` +
+            `    ----fastpop----\n` +
+            `    stop\n` +
+            `  .\n` +
+            `----fastpop----\n`
+        )
+    })
+
+    test('Should handle early fastpop stop (middle)', async () => {
+        await testHighlights(
+            `fastpush\n` +
+            `  if B9 then\n` +
+            `    |fastpop\n` +
+            `    stop\n` +
+            `  .\n` +
+            `fastpop\n`,
+            // Expects:
+            `----fastpush----\n` +
+            `  if B9 then\n` +
+            `    ----fastpop----\n` +
+            `    stop\n` +
+            `  .\n` +
+            `fastpop\n`
+        )
+    })
+
+    test('Should handle early fastpop stop (reverse)', async () => {
+        await testHighlights(
+            `fastpush\n` +
+            `  if B9 then\n` +
+            `    fastpop\n` +
+            `    stop\n` +
+            `  .\n` +
+            `|fastpop\n`,
+            // Expects:
+            `----fastpush----\n` +
+            `  if B9 then\n` +
+            `    fastpop\n` +
+            `    stop\n` +
+            `  .\n` +
+            `----fastpop----\n`
+        )
+    })
+
+    test('Should handle nested early fastpop stop', async () => {
+        await testHighlights(
+            `fastpush\n` +
+            `  |fastpush\n` +
+            `    if B9 then\n` +
+            `      fastpop\n` +
+            `      stop\n` +
+            `    .\n` +
+            `  fastpop\n` +
+            `fastpop\n`,
+            // Expects:
+            `fastpush\n` +
+            `  ----fastpush----\n` +
+            `    if B9 then\n` +
+            `      ----fastpop----\n` +
+            `      stop\n` +
+            `    .\n` +
+            `  ----fastpop----\n` +
+            `fastpop\n`,
+        )
+    })
+
+    test('Should handle nested early fastpop stop (reverse)', async () => {
+        await testHighlights(
+            `fastpush\n` +
+            `  fastpush\n` +
+            `    if B9 then\n` +
+            `      fastpop\n` +
+            `      stop\n` +
+            `    .\n` +
+            `  |fastpop\n` +
+            `fastpop\n`,
+            // Expects:
+            `fastpush\n` +
+            `  ----fastpush----\n` +
+            `    if B9 then\n` +
+            `      fastpop\n` +
+            `      stop\n` +
+            `    .\n` +
+            `  ----fastpop----\n` +
+            `fastpop\n`,
+        )
+    })
+
+    test('Should ignore comments containing code', async () => {
+        await testHighlights(
+            `p|ush\n` +
+            `  ! pop\n` +
+            `pop\n`,
+            // Expects:
+            `----push----\n` +
+            `  ! pop\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should ignore comments containing code (reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  ! push\n` +
+            `p|op\n`,
+            // Expects:
+            `----push----\n` +
+            `  ! push\n` +
+            `----pop----\n`
+        )
+    })
+
+
+    test('Should ignore strings containing code', async () => {
+        await testHighlights(
+            `p|ush\n` +
+            `  msgp "pop goes the weasel."\n` +
+            `pop\n`,
+            // Expects:
+            `----push----\n` +
+            `  msgp "pop goes the weasel."\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should ignore strings containing code (reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  msgp "push goes the weasel."\n` +
+            `p|op\n`,
+            // Expects:
+            `----push----\n` +
+            `  msgp "push goes the weasel."\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should gracefully fail with broken pairs', async () => {
+        await testHighlights(
+            `p|ush\n` +
+            `  msgp "inside broken code"\n` +
+            `fastpop\n`,
+            // Expects:
+            `----push----\n` +
+            `  msgp "inside broken code"\n` +
+            `fastpop\n`
+        )
+    })
+
+    test('Should gracefully fail with broken pairs (reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  msgp "inside broken code"\n` +
+            `|fastpop\n`,
+            // Expects:
+            `push\n` +
+            `  msgp "inside broken code"\n` +
+            `----fastpop----\n`
+        )
+    })
+
+    test('Should highlight related else statements', async () => {
+        await testHighlights(
+            `|if A1 then\n` +
+            `  fastpop\n` +
+            `  stop\n` +
+            `else_ifnot A8 then\n` +
+            `  msgp "foo"\n` +
+            `else_if A8 then\n` +
+            `  msgp "hm"\n` +
+            `else\n` +
+            `  msgp "hmmm"\n` +
+            `.\n`,
+            // Expects:
+            `----if---- A1 ----then----\n` +
+            `  fastpop\n` +
+            `  stop\n` +
+            `----else_ifnot---- A8 ----then----\n` +
+            `  msgp "foo"\n` +
+            `----else_if---- A8 ----then----\n` +
+            `  msgp "hm"\n` +
+            `----else----\n` +
+            `  msgp "hmmm"\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should highlight related else statements (reverse)', async () => {
+        await testHighlights(
+            `if A1 then\n` +
+            `  fastpop\n` +
+            `  stop\n` +
+            `else_ifnot A8 then\n` +
+            `  msgp "foo"\n` +
+            `else_if A8 then\n` +
+            `  msgp "hm"\n` +
+            `else\n` +
+            `  msgp "hmmm"\n` +
+            `.|\n`,
+            // Expects:
+            `----if---- A1 ----then----\n` +
+            `  fastpop\n` +
+            `  stop\n` +
+            `----else_ifnot---- A8 ----then----\n` +
+            `  msgp "foo"\n` +
+            `----else_if---- A8 ----then----\n` +
+            `  msgp "hm"\n` +
+            `----else----\n` +
+            `  msgp "hmmm"\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should highlight matching MM start/end', async () => {
+        await testHighlights(
+            `: "$FOO_BAR|"\n` +
+            `  msgp "inside"\n` +
+            `.\n`,
+            // Expects:
+            `----\: "$FOO_BAR"----\n` +
+            `  msgp "inside"\n` +
+            `----\.----\n`,
+        )
+    })
+
+    test('Should highlight matching MM start/end (reverse)', async () => {
+        await testHighlights(
+            `: "$FOO_BAR"\n` +
+            `  msgp "inside"\n` +
+            `|.\n`,
+            // Expects:
+            `----\: "$FOO_BAR"----\n` +
+            `  msgp "inside"\n` +
+            `----\.----\n`,
+        )
+    })
+
+    test('Should handle nested push/pop (outer cursor)', async () => {
+        await testHighlights(
+            `|push\n` +
+            `  push\n` +
+            `  pop\n` +
+            `pop\n`,
+            // Expects:
+            `----push----\n` +
+            `  push\n` +
+            `  pop\n` +
+            `----pop----\n`,
+        )
+    })
+
+    test('Should handle nested push/pop (outer cursor; reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  push\n` +
+            `  pop\n` +
+            `|pop\n`,
+            // Expects:
+            `----push----\n` +
+            `  push\n` +
+            `  pop\n` +
+            `----pop----\n`,
+        )
+    })
+
+    test('Should handle nested push/pop (inner cursor)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  |push\n` +
+            `  pop\n` +
+            `pop\n`,
+            // Expects:
+            `push\n` +
+            `  ----push----\n` +
+            `  ----pop----\n` +
+            `pop\n`,
+        )
+    })
+
+    test('Should handle nested push/pop (inner cursor; reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  push\n` +
+            `  |pop\n` +
+            `pop\n`,
+            // Expects:
+            `push\n` +
+            `  ----push----\n` +
+            `  ----pop----\n` +
+            `pop\n`,
+        )
+    })
+
+    test('Should handle nested push/pop in if block', async () => {
+        await testHighlights(
+            `p|ush\n` +
+            `  if A8 then\n` +
+            `    push\n` +
+            `    pop\n` +
+            `  .\n` +
+            `pop\n`,
+            // Expects:
+            `----push----\n` +
+            `  if A8 then\n` +
+            `    push\n` +
+            `    pop\n` +
+            `  .\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should handle nested push/pop in if block (reverse)', async () => {
+        await testHighlights(
+            `push\n` +
+            `  if A8 then\n` +
+            `    push\n` +
+            `    pop\n` +
+            `  .\n` +
+            `p|op\n`,
+            // Expects:
+            `----push----\n` +
+            `  if A8 then\n` +
+            `    push\n` +
+            `    pop\n` +
+            `  .\n` +
+            `----pop----\n`
+        )
+    })
+
+    test('Should handle nested if/else case', async () => {
+        await testHighlights(
+            `|if A8 then\n` +
+            `else\n` +
+            `  if A9 then\n` +
+            `  else\n` +
+            `  .\n` +
+            `.\n`,
+            // Expects:
+            `----if---- A8 ----then----\n` +
+            `----else----\n` +
+            `  if A9 then\n` +
+            `  else\n` +
+            `  .\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should highlight corresponding IS/DEFAULT on WHEN', async () => {
+        await testHighlights(
+            `|when A8\n` +
+            `  is 8\n` +
+            `  .\n` +
+            `  default\n` +
+            `  .\n` +
+            `.\n`,
+            // Expects:
+            `----when---- A8\n` +
+            `  ----is---- 8\n` +
+            `  ----.----\n` +
+            `  ----default----\n` +
+            `  ----.----\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should highlight corresponding IS/DEFAULT on WHEN (cursor at end of default)', async () => {
+        await testHighlights(
+            `when A8\n` +
+            `  is 8\n` +
+            `  .\n` +
+            `  default\n` +
+            `  .|\n` +
+            `.\n`,
+            // Expects:
+            `----when---- A8\n` +
+            `  ----is---- 8\n` +
+            `  ----.----\n` +
+            `  ----default----\n` +
+            `  ----.----\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should handle IS as if cursor was next to corresponding WHEN', async () => {
+        await testHighlights(
+            `when A8\n` +
+            `  |is 8\n` +
+            `  .\n` +
+            `.\n`,
+            // Expects:
+            `----when---- A8\n` +
+            `  ----is---- 8\n` +
+            `  ----.----\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should handle nested WHEN', async () => {
+        await testHighlights(
+            `|when A8\n` +
+            `  is 8\n` +
+            `    when A9\n` +
+            `      is 9\n` +
+            `      .\n` +
+            `      default\n` +
+            `      .\n` +
+            `    .\n` +
+            `  .\n` +
+            `  default\n` +
+            `  .\n` +
+            `.\n`,
+            // Expects:
+            `----when---- A8\n` +
+            `  ----is---- 8\n` +
+            `    when A9\n` +
+            `      is 9\n` +
+            `      .\n` +
+            `      default\n` +
+            `      .\n` +
+            `    .\n` +
+            `  ----.----\n` +
+            `  ----default----\n` +
+            `  ----.----\n` +
+            `----.----\n`,
+        )
+    })
+
+    test('Should handle nested WHEN (reverse)', async () => {
+        await testHighlights(
+            `when A8\n` +
+            `  is 8\n` +
+            `    when A9\n` +
+            `      is 9\n` +
+            `      .\n` +
+            `      default\n` +
+            `      .\n` +
+            `    .\n` +
+            `  .\n` +
+            `  default\n` +
+            `  .\n` +
+            `|.\n`,
+            // Expects:
+            `----when---- A8\n` +
+            `  ----is---- 8\n` +
+            `    when A9\n` +
+            `      is 9\n` +
+            `      .\n` +
+            `      default\n` +
+            `      .\n` +
+            `    .\n` +
+            `  ----.----\n` +
+            `  ----default----\n` +
+            `  ----.----\n` +
+            `----.----\n`,
+        )
+    })
+})

--- a/test/suite/highlightProvider.test.ts
+++ b/test/suite/highlightProvider.test.ts
@@ -678,4 +678,160 @@ suite('Highlight Provider Test Suite', () => {
             `----.----\n`,
         )
     })
+
+    test('Should highlight object tokens', async () => {
+        await testHighlights(
+            `set |NO1 to NO2\n` +
+            `msgp "$O1N"`,
+            // Expects:
+            `set ----NO1---- to NO2\n` +
+            `msgp "----$O1N----"`,
+        )
+    })
+
+    test('Should highlight object tokens (reverse)', async () => {
+        await testHighlights(
+            `set NO1 to NO2\n` +
+            `msgp "$|O1N"`,
+            // Expects:
+            `set ----NO1---- to NO2\n` +
+            `msgp "----$O1N----"`,
+        )
+    })
+
+    test('Should highlight player tokens', async () => {
+        await testHighlights(
+            `set |NP1 to NP2\n` +
+            `msgp "$P1N"`,
+            // Expects:
+            `set ----NP1---- to NP2\n` +
+            `msgp "----$P1N----"`,
+        )
+    })
+
+    test('Should highlight player tokens (reverse)', async () => {
+        await testHighlights(
+            `set NP1 to NP2\n` +
+            `msgp "$|P1N"`,
+            // Expects:
+            `set ----NP1---- to NP2\n` +
+            `msgp "----$P1N----"`,
+        )
+    })
+
+    test('Should highlight creature tokens', async () => {
+        await testHighlights(
+            `set |NC1 to NC2\n` +
+            `msgp "$C1N"`,
+            // Expects:
+            `set ----NC1---- to NC2\n` +
+            `msgp "----$C1N----"`,
+        )
+    })
+
+    test('Should highlight creature tokens (reverse)', async () => {
+        await testHighlights(
+            `set NC1 to NC2\n` +
+            `msgp "$|C1N"`,
+            // Expects:
+            `set ----NC1---- to NC2\n` +
+            `msgp "----$C1N----"`,
+        )
+    })
+
+    test('Should highlight event tokens', async () => {
+        await testHighlights(
+            `set |NE1 to NE2\n` +
+            `msgp "$E1N"`,
+            // Expects:
+            `set ----NE1---- to NE2\n` +
+            `msgp "----$E1N----"`,
+        )
+    })
+
+    test('Should highlight event tokens (reverse)', async () => {
+        await testHighlights(
+            `set NE1 to NE2\n` +
+            `msgp "$|E1N"`,
+            // Expects:
+            `set ----NE1---- to NE2\n` +
+            `msgp "----$E1N----"`,
+        )
+    })
+
+    test('Should highlight room tokens', async () => {
+        await testHighlights(
+            `set |NR1 to NR2\n` +
+            `msgp "$r1"`,
+            // Expects:
+            `set ----NR1---- to NR2\n` +
+            `msgp "----$r1----"`,
+        )
+    })
+
+    test('Should highlight room tokens (reverse)', async () => {
+        await testHighlights(
+            `set NR1 to NR2\n` +
+            `msgp "|$r1"`,
+            // Expects:
+            `set ----NR1---- to NR2\n` +
+            `msgp "----$r1----"`,
+        )
+    })
+
+    test('Should highlight x tokens for player', async () => {
+        await testHighlights(
+            `set NC1 to NC2\n` +
+            `set |NP1 to NP2\n` +
+            `msgp "$X1"`,
+            // Expects:
+            `set NC1 to NC2\n` +
+            `set ----NP1---- to NP2\n` +
+            `msgp "----$X1----"`,
+        )
+    })
+
+    test('Should highlight x tokens for creature', async () => {
+        await testHighlights(
+            `set |NC1 to NC2\n` +
+            `set NP1 to NP2\n` +
+            `msgp "$X1"`,
+            // Expects:
+            `set ----NC1---- to NC2\n` +
+            `set NP1 to NP2\n` +
+            `msgp "----$X1----"`,
+        )
+    })
+
+    test('Should highlight player/creature tokens for x token', async () => {
+        await testHighlights(
+            `set NC1 to NC2\n` +
+            `set NP1 to NP2\n` +
+            `msgp "$|X1"`,
+            // Expects:
+            `set ----NC1---- to NC2\n` +
+            `set ----NP1---- to NP2\n` +
+            `msgp "----$X1----"`,
+        )
+    })
+
+    test('Should highlight A register in string', async () => {
+        await testHighlights(
+            `set |A1 to 3\n` +
+            `msgp "$A1"`,
+            // Expects:
+            `set ----A1---- to 3\n` +
+            `msgp "$----A1----"`,
+        )
+    })
+
+    test('Should highlight A register in string (reverse)', async () => {
+        await testHighlights(
+            `set A1 to 3\n` +
+            `msgp "$|A1"`,
+            // Expects:
+            `set ----A1---- to 3\n` +
+            `msgp "$----A1----"`,
+        )
+    })
 })

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -1,0 +1,25 @@
+import * as path from 'path'
+import * as Mocha from 'mocha'
+import * as glob from 'glob'
+
+export async function run(): Promise<void> {
+    const mocha = new Mocha({
+        ui: 'tdd',
+        color: true
+    });
+
+    // Find all test files
+    const testsRoot = __dirname;
+    const files = await glob.glob('**/*.test.js', { cwd: testsRoot })
+
+    // Add files to the test suite
+    for (const f of files) {
+        mocha.addFile(path.resolve(testsRoot, f))
+    }
+
+    return new Promise((resolve, reject) => {
+        mocha.run(failures => {
+            failures ? reject(new Error(`${failures} tests failed`)) : resolve()
+        });
+    });
+}

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -3,23 +3,86 @@ import * as Mocha from 'mocha'
 import * as glob from 'glob'
 
 export async function run(): Promise<void> {
-    const mocha = new Mocha({
+    // Parse filters from environment variables
+    let fileFilters: string[] = []
+    let testFilters: string[] = []
+
+    if (process.env.FILE_FILTERS) {
+        try {
+            fileFilters = JSON.parse(process.env.FILE_FILTERS)
+        } catch (e) {
+            console.error('Error parsing FILE_FILTERS:', e)
+        }
+    }
+
+    if (process.env.TEST_FILTERS) {
+        try {
+            testFilters = JSON.parse(process.env.TEST_FILTERS)
+        } catch (e) {
+            console.error('Error parsing TEST_FILTERS:', e)
+        }
+    }
+
+    // Configure Mocha
+    const mochaOpts: Mocha.MochaOptions = {
         ui: 'tdd',
         color: true
-    });
+    }
+
+    // If test name filters are provided, use Mocha's grep option
+    if (testFilters.length === 1) {
+        mochaOpts.grep = new RegExp(testFilters[0])
+    } else if (testFilters.length > 1) {
+        // For multiple test filters, create a regex that matches any of them
+        mochaOpts.grep = new RegExp(testFilters.map(f => `(${f})`).join('|'))
+    }
+
+    const mocha = new Mocha(mochaOpts)
 
     // Find all test files
-    const testsRoot = __dirname;
+    const testsRoot = __dirname
     const files = await glob.glob('**/*.test.js', { cwd: testsRoot })
 
+    // Filter test files if file filters were provided
+    const filteredFiles = fileFilters.length > 0
+        ? files.filter(file => {
+            return fileFilters.some(filter => {
+                const fileNameWithoutExtension = path.basename(file, '.test.js')
+                return fileNameWithoutExtension === filter ||
+                       file.includes(filter) ||
+                       fileNameWithoutExtension.includes(filter)
+            })
+        })
+        : files
+
+    // Log filtering information
+    if (fileFilters.length > 0) {
+        console.log(`File filters: ${fileFilters.join(', ')}`)
+        console.log(`Matching files (${filteredFiles.length}): ${filteredFiles.join(', ')}`)
+    }
+
+    if (testFilters.length > 0) {
+        console.log(`Test name filters: ${testFilters.join(', ')}`)
+    }
+
+    if (fileFilters.length === 0 && testFilters.length === 0) {
+        console.log(`Running all ${files.length} test files`)
+    }
+
     // Add files to the test suite
-    for (const f of files) {
+    for (const f of filteredFiles) {
         mocha.addFile(path.resolve(testsRoot, f))
     }
 
+    // Run the tests
     return new Promise((resolve, reject) => {
-        mocha.run(failures => {
-            failures ? reject(new Error(`${failures} tests failed`)) : resolve()
-        });
-    });
+        try {
+            mocha.run(failures => {
+                failures ? reject(new Error(`${failures} tests failed`)) : resolve()
+            })
+        } catch (err) {
+            console.error('Error running tests:', err)
+            reject(err)
+        }
+    })
 }

--- a/test/suite/util/formattingUtil.test.ts
+++ b/test/suite/util/formattingUtil.test.ts
@@ -1,0 +1,251 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { formatIndentation } from '../../../gsl/util/formattingUtil'
+
+suite('Formatting Utility Test Suite', () => {
+    async function testFormatIndentation(input: string, expected: string): Promise<void> {
+        // Create a document with the input text
+        const document = await vscode.workspace.openTextDocument({
+            language: 'gsl',
+            content: input
+        })
+
+        // Call formatIndentation with the document
+        const formatted = formatIndentation(document)
+
+        // Assert the result matches expected output
+        assert.strictEqual(formatted, expected)
+    }
+
+    test('Should indent an MM', async () => {
+        await testFormatIndentation(
+            `: "$FOOBAR"\n` +
+            `msgp "foobar"\n` +
+            `.\n`,
+            // Expects:
+            `: "$FOOBAR"\n` +
+            `  msgp "foobar"\n` +
+            `.\n`
+        )
+    })
+
+    test('Should preserve comments ', async () => {
+        await testFormatIndentation(
+            `: "$FOOBAR" ! a\n` +
+            `  ! a whole line comment here\n` +
+            `msgp "foobar" ! b\n` +
+            `. ! c`,
+            // Expects:
+            `: "$FOOBAR" ! a\n` +
+            `  ! a whole line comment here\n` +
+            `  msgp "foobar" ! b\n` +
+            `. ! c`
+        )
+    })
+
+    test('Should handle nested blocks with if-then', async () => {
+        await testFormatIndentation(
+            `: "$FOOBAR"\n` +
+            `if A8 then\n` +
+            `msgp "foobar"\n` +
+            `.\n` +
+            `.\n`,
+            // Expects:
+            `: "$FOOBAR"\n` +
+            `  if A8 then\n` +
+            `    msgp "foobar"\n` +
+            `  .\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle multiple levels of nesting', async () => {
+        await testFormatIndentation(
+            `: "$OUTER"\n` +
+            `if A8 then\n` +
+            `if B9 then\n` +
+            `msgp "nested"\n` +
+            `.\n` +
+            `msgp "less nested"\n` +
+            `.\n` +
+            `.\n`,
+            // Expects:
+            `: "$OUTER"\n` +
+            `  if A8 then\n` +
+            `    if B9 then\n` +
+            `      msgp "nested"\n` +
+            `    .\n` +
+            `    msgp "less nested"\n` +
+            `  .\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle push and pop operations', async () => {
+        await testFormatIndentation(
+            `push\n` +
+            `msgp "inside push"\n` +
+            `pop\n`,
+            // Expects:
+            `push\n` +
+            `  msgp "inside push"\n` +
+            `pop\n`
+        )
+    })
+
+    test('Should handle fastpush and fastpop operations', async () => {
+        await testFormatIndentation(
+            `fastpush\n` +
+            `msgp "inside fastpush"\n` +
+            `fastpop\n`,
+            // Expects:
+            `fastpush\n` +
+            `  msgp "inside fastpush"\n` +
+            `fastpop\n`
+        )
+    })
+
+    test('Should handle else blocks', async () => {
+        await testFormatIndentation(
+            `if A8 then\n` +
+            `msgp "then branch"\n` +
+            `else\n` +
+            `msgp "else branch"\n` +
+            `.\n`,
+            // Expects:
+            `if A8 then\n` +
+            `  msgp "then branch"\n` +
+            `else\n` +
+            `  msgp "else branch"\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle case structures with is/default', async () => {
+        await testFormatIndentation(
+            `when A8\n` +
+            `is 1\n` +
+            `msgp "case 1"\n` +
+            `.\n` +
+            `is 2\n` +
+            `msgp "case 2"\n` +
+            `.\n` +
+            `default\n` +
+            `msgp "default case"\n` +
+            `.\n` +
+            `.\n`,
+            // Expects:
+            `when A8\n` +
+            `  is 1\n` +
+            `    msgp "case 1"\n` +
+            `  .\n` +
+            `  is 2\n` +
+            `    msgp "case 2"\n` +
+            `  .\n` +
+            `  default\n` +
+            `    msgp "default case"\n` +
+            `  .\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle empty lines', async () => {
+        await testFormatIndentation(
+            `if A8 then\n` +
+            `msgp "line 1"\n` +
+            `\n` +
+            `msgp "line 2"\n` +
+            `.\n`,
+            // Expects:
+            `if A8 then\n` +
+            `  msgp "line 1"\n` +
+            `\n` +
+            `  msgp "line 2"\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle else_if blocks', async () => {
+        await testFormatIndentation(
+            `if A8 then\n` +
+            `msgp "then branch"\n` +
+            `else_if B9 then\n` +
+            `msgp "else if branch"\n` +
+            `else\n` +
+            `msgp "else branch"\n` +
+            `.\n`,
+            // Expects:
+            `if A8 then\n` +
+            `  msgp "then branch"\n` +
+            `else_if B9 then\n` +
+            `  msgp "else if branch"\n` +
+            `else\n` +
+            `  msgp "else branch"\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle loops', async () => {
+        await testFormatIndentation(
+            `loop\n` +
+            `msgp "inside loop"\n` +
+            `.\n`,
+            // Expects:
+            `loop\n` +
+            `  msgp "inside loop"\n` +
+            `.\n`
+        )
+    })
+
+    test('Should handle early pop stop', async () => {
+        await testFormatIndentation(
+            `push\n` +
+            `if A8 then\n` +
+            `pop\n` +
+            `stop\n` +
+            `.\n` +
+            `pop\n`,
+            // Expects:
+            `push\n` +
+            `  if A8 then\n` +
+            `    pop\n` +
+            `    stop\n` +
+            `  .\n` +
+            `pop\n`,
+        )
+    })
+
+    test('Should handle early fastpop stop', async () => {
+        await testFormatIndentation(
+            `fastpush\n` +
+            `if A8 then\n` +
+            `fastpop\n` +
+            `stop\n` +
+            `.\n` +
+            `fastpop\n`,
+            // Expects:
+            `fastpush\n` +
+            `  if A8 then\n` +
+            `    fastpop\n` +
+            `    stop\n` +
+            `  .\n` +
+            `fastpop\n`,
+        )
+    })
+
+    test('Should leave unindented comments alone', async () => {
+        await testFormatIndentation(
+            `: "$do_stuff"\n` +
+            `! Expects: NP0\n` +
+            `! Returns: None\n` +
+            `msgp "stuff"\n` +
+            `.\n`,
+            // Expects:
+            `: "$do_stuff"\n` +
+            `! Expects: NP0\n` +
+            `! Returns: None\n` +
+            `  msgp "stuff"\n` +
+            `.\n`,
+        )
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
 		"outDir": ".",
 		"rootDir": "."
 	},
-	"include": ["extension.ts","gsl","gsl-language-server"],  
+	"include": ["extension.ts","gsl","gsl-language-server", "test"],
 	"exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
This MR adds the following:

- Clarification in the Download Script/Verb prompt that multiple scripts/verbs may be downloaded, using terminology `script(s)` and `verb(s)`.
- 120 character max width diagnostic, along with Quick Fix to redistribute the content over multiple lines. Also includes "Redistribute 
- "Collapse Multiline String" Code Action. Allows strings that span multiple lines to be collapsed to a single line, allowing for easier copy/paste/editing.
- "Combine Messages" Code Action. Same as above but for message commands. Allows a sequence of identical message commands to be collapsed into a single command, e.g. `msgp "foo$\"\nmsgp "bar"` becomes `msgp "foobar"`.
- "Align Comments" Code Action. Right-aligns comments while still respecting the 120 character limit. Will not edit whole-line comments.
- "Format Document Indentation" Command. Will autoformat all indentation in the document. Respects early stops with pop/fastpop, i.e. recognizes that it should not unindent in those cases.
- Updated highlight provider to be smarter about blocks, including early stops with `fastpop`/`pop`. If block highlights are not applicable, revert to the default vscode behavior of highlighting all instances of the word in range.

https://github.com/user-attachments/assets/ddd3d61f-0b5b-4f93-83c7-1d2ce66bdff4

https://github.com/user-attachments/assets/9349d196-6577-43d8-8ca9-16ebf4e07f26

https://github.com/user-attachments/assets/bf1a6566-a0e9-4f8a-9fb1-dd5e985d2c1b

https://github.com/user-attachments/assets/a287cc12-8214-47ba-8a96-b6672990bd67

https://github.com/user-attachments/assets/62257dcb-fb47-4032-8056-0a964d33d1ae