### PR TITLE
Scope line-too-long Diagnostic to GSL Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the GSL Editor extension will be documented in this file.
 
+## [1.14.2] - 2025-05-13
+
+### Added
+
+- Fixed issue where "line-too-long" diagnostic would trigger on non-GSL documents.
+
 ## [1.14.1] - 2025-05-05
 
 ### Added

--- a/gsl/diagnostics.ts
+++ b/gsl/diagnostics.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { GSL_LANGUAGE_ID } from './const';
 
 export const LINE_TOO_LONG = 'line-too-long';
 export const MAX_LINE_LENGTH = 118;
@@ -19,6 +20,11 @@ function refreshDiagnostics(
     document: vscode.TextDocument,
     lineLengthDiagnostics: vscode.DiagnosticCollection
 ): void {
+    // Only run diagnostics for GSL language documents
+    if (document.languageId !== GSL_LANGUAGE_ID) {
+        return;
+    }
+
     const diagnostics: vscode.Diagnostic[] = [];
 
     for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {


### PR DESCRIPTION
We don't want the line-too-long diagnostic to complain alert on non-GSL documents.