### PR TITLE
Add get room/exist data tools for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the GSL Editor extension will be documented in this file.
 
+## [1.19.0] - 2026-04-20
+
+### Added
+
+- Added Copilot tool `gsl_get_room_data` to retrieve full room data via `/sr`, including Prime/Dev targeting.
+- Added Copilot tool `gsl_get_existence_data` to retrieve full existence data via `/se`, including Prime/Dev targeting.
+
 ## [1.18.0] - 2026-03-01
 
 **Important:** To fully benefit from this release, rerun `GSL: User Setup` so your stored Development and Prime configuration is refreshed.

--- a/extension.ts
+++ b/extension.ts
@@ -1323,6 +1323,19 @@ export class VSCodeIntegration {
         return result;
     }
 
+    async getExistenceData(
+        existenceId: number,
+        instance: "prime" | "dev",
+    ): Promise<string> {
+        return this.executeShowCommandOnInstance(
+            instance,
+            `/se ${existenceId}`,
+            /^Showing /,
+            /^Flags:/,
+            /^Existence ".*?" not found\./,
+        );
+    }
+
     async getRoomData(
         roomId: number,
         instance: "prime" | "dev",

--- a/extension.ts
+++ b/extension.ts
@@ -1272,6 +1272,70 @@ export class VSCodeIntegration {
         });
     }
 
+    private async executeShowCommand(
+        client: EditorClientInterface,
+        command: string,
+        captureStart: RegExp,
+        captureEnd: RegExp,
+        abortPattern: RegExp,
+    ): Promise<string> {
+        const TIMEOUT_MS = 15000;
+        const lines = await client.executeCommand(command, {
+            captureStart,
+            captureEnd,
+            abortPattern,
+            timeoutMillis: TIMEOUT_MS,
+            includeStartLine: true,
+            includeEndLine: true,
+        });
+        return lines.join("\n");
+    }
+
+    private async executeShowCommandOnInstance(
+        instance: "prime" | "dev",
+        command: string,
+        captureStart: RegExp,
+        captureEnd: RegExp,
+        abortPattern: RegExp,
+    ): Promise<string> {
+        const task = (client: EditorClientInterface) =>
+            this.executeShowCommand(
+                client,
+                command,
+                captureStart,
+                captureEnd,
+                abortPattern,
+            );
+
+        if (instance === "prime") {
+            return primeService.doPrimeEditorClientTask(
+                task,
+                this.getPrimeServiceDependencies(),
+            );
+        }
+
+        const result = await this.withEditorClient(task);
+        if (result === undefined) {
+            throw new Error(
+                "Dev server not configured. Run 'GSL: User Setup' first.",
+            );
+        }
+        return result;
+    }
+
+    async getRoomData(
+        roomId: number,
+        instance: "prime" | "dev",
+    ): Promise<string> {
+        return this.executeShowCommandOnInstance(
+            instance,
+            `/sr ${roomId}`,
+            /^Showing room #\d+/,
+            /^Flags:/,
+            /does not exist or could not be loaded for some reason/,
+        );
+    }
+
     private registerCommands() {
         let subscription: Disposable;
         subscription = commands.registerCommand(

--- a/gsl/copilotTools.ts
+++ b/gsl/copilotTools.ts
@@ -36,6 +36,11 @@ interface IGetRoomDataParams {
     instance?: "prime" | "dev";
 }
 
+interface IGetExistenceDataParams {
+    existenceId: number;
+    instance?: "prime" | "dev";
+}
+
 const AGENT_UPLOAD_SCRIPT_NUMBER = 24661;
 
 // ---------------------------------------------------------------------------
@@ -569,6 +574,79 @@ function parseRequiredRoomId(value: number | undefined): number {
     return value;
 }
 
+/**
+ * Validates and returns an existence ID (positive or negative integer).
+ */
+function parseRequiredExistenceId(value: number | undefined): number {
+    if (value === undefined || !Number.isInteger(value) || value === 0) {
+        throw new Error(
+            "Missing or invalid existenceId. Provide a non-zero integer.",
+        );
+    }
+    return value;
+}
+
+class GetExistenceDataTool implements vscode.LanguageModelTool<IGetExistenceDataParams> {
+    async prepareInvocation(
+        options: vscode.LanguageModelToolInvocationPrepareOptions<IGetExistenceDataParams>,
+        _token: vscode.CancellationToken,
+    ) {
+        parseRequiredExistenceId(options.input.existenceId);
+        const instance = options.input.instance ?? "dev";
+        return {
+            invocationMessage: `Fetching existence ${options.input.existenceId} from ${instance} server\u2026`,
+        };
+    }
+
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<IGetExistenceDataParams>,
+        token: vscode.CancellationToken,
+    ): Promise<vscode.LanguageModelToolResult> {
+        try {
+            throwIfCancelled(token);
+            if (!vscRef) {
+                throw new Error(
+                    "GSL extension is not active. Open a GSL file to activate it.",
+                );
+            }
+
+            const existenceId = parseRequiredExistenceId(
+                options.input.existenceId,
+            );
+            const instance = options.input.instance ?? "dev";
+
+            const rawOutput = await withCancellation(
+                vscRef.getExistenceData(existenceId, instance),
+                token,
+            );
+
+            if (!rawOutput || rawOutput.trim().length === 0) {
+                return new vscode.LanguageModelToolResult([
+                    new vscode.LanguageModelTextPart(
+                        `Existence ${existenceId}: No data returned from ${instance} server. ` +
+                            `The existence may not exist.`,
+                    ),
+                ]);
+            }
+
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(rawOutput),
+            ]);
+        } catch (e) {
+            if (isToolCancelled(e)) {
+                return createCancelledToolResult(
+                    "Get existence data was cancelled before completion.",
+                );
+            }
+            throw new Error(
+                `Failed to get existence data for ${options.input.existenceId ?? "(missing existenceId)"}: ${
+                    e instanceof Error ? e.message : String(e)
+                }`,
+            );
+        }
+    }
+}
+
 class GetRoomDataTool implements vscode.LanguageModelTool<IGetRoomDataParams> {
     async prepareInvocation(
         options: vscode.LanguageModelToolInvocationPrepareOptions<IGetRoomDataParams>,
@@ -659,5 +737,9 @@ export function registerCopilotTools(
             new GetCurrentAuthorTool(),
         ),
         vscode.lm.registerTool("gsl_get_room_data", new GetRoomDataTool()),
+        vscode.lm.registerTool(
+            "gsl_get_existence_data",
+            new GetExistenceDataTool(),
+        ),
     );
 }

--- a/gsl/copilotTools.ts
+++ b/gsl/copilotTools.ts
@@ -31,6 +31,11 @@ interface IUploadScriptParams {
 
 type IGetCurrentAuthorParams = Record<string, never>;
 
+interface IGetRoomDataParams {
+    roomId: number;
+    instance?: "prime" | "dev";
+}
+
 const AGENT_UPLOAD_SCRIPT_NUMBER = 24661;
 
 // ---------------------------------------------------------------------------
@@ -553,6 +558,77 @@ class GetCurrentAuthorTool implements vscode.LanguageModelTool<IGetCurrentAuthor
 // ---------------------------------------------------------------------------
 
 /**
+ * Validates and returns a room ID.
+ */
+function parseRequiredRoomId(value: number | undefined): number {
+    if (value === undefined || !Number.isInteger(value) || value < 1) {
+        throw new Error(
+            "Missing or invalid roomId. Provide a positive integer.",
+        );
+    }
+    return value;
+}
+
+class GetRoomDataTool implements vscode.LanguageModelTool<IGetRoomDataParams> {
+    async prepareInvocation(
+        options: vscode.LanguageModelToolInvocationPrepareOptions<IGetRoomDataParams>,
+        _token: vscode.CancellationToken,
+    ) {
+        parseRequiredRoomId(options.input.roomId);
+        const instance = options.input.instance ?? "dev";
+        return {
+            invocationMessage: `Fetching room ${options.input.roomId} from ${instance} server\u2026`,
+        };
+    }
+
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<IGetRoomDataParams>,
+        token: vscode.CancellationToken,
+    ): Promise<vscode.LanguageModelToolResult> {
+        try {
+            throwIfCancelled(token);
+            if (!vscRef) {
+                throw new Error(
+                    "GSL extension is not active. Open a GSL file to activate it.",
+                );
+            }
+
+            const roomId = parseRequiredRoomId(options.input.roomId);
+            const instance = options.input.instance ?? "dev";
+
+            const rawOutput = await withCancellation(
+                vscRef.getRoomData(roomId, instance),
+                token,
+            );
+
+            if (!rawOutput || rawOutput.trim().length === 0) {
+                return new vscode.LanguageModelToolResult([
+                    new vscode.LanguageModelTextPart(
+                        `Room ${roomId}: No data returned from ${instance} server. ` +
+                            `The room may not exist.`,
+                    ),
+                ]);
+            }
+
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(rawOutput),
+            ]);
+        } catch (e) {
+            if (isToolCancelled(e)) {
+                return createCancelledToolResult(
+                    "Get room data was cancelled before completion.",
+                );
+            }
+            throw new Error(
+                `Failed to get room data for room ${
+                    options.input.roomId ?? "(missing roomId)"
+                }: ${e instanceof Error ? e.message : String(e)}`,
+            );
+        }
+    }
+}
+
+/**
  * Registers the Copilot language-model tools.  Call from `activate()`.
  *
  * @param context - the extension context (for subscriptions)
@@ -582,5 +658,6 @@ export function registerCopilotTools(
             "gsl-get-current-author",
             new GetCurrentAuthorTool(),
         ),
+        vscode.lm.registerTool("gsl_get_room_data", new GetRoomDataTool()),
     );
 }

--- a/gsl/editorClient.ts
+++ b/gsl/editorClient.ts
@@ -856,12 +856,15 @@ class EditorClient extends BaseGameClient {
         {
             captureStart,
             captureEnd,
+            abortPattern,
             timeoutMillis,
             includeStartLine,
             includeEndLine,
         }: {
             captureStart: RegExp;
             captureEnd: RegExp;
+            /** If matched before captureStart, resolves immediately with that line. */
+            abortPattern?: RegExp;
             timeoutMillis: number;
             includeStartLine?: boolean;
             includeEndLine?: boolean;
@@ -876,6 +879,13 @@ class EditorClient extends BaseGameClient {
             const output = new OutputProcessor((line: string) => {
                 // Check capture start
                 if (!seenStart) {
+                    // Check abort pattern before start marker
+                    if (abortPattern && line.match(abortPattern)) {
+                        this.off("text", processText);
+                        clearTimeout(timeout);
+                        resolve([line]);
+                        return;
+                    }
                     if (line.match(captureStart)) {
                         seenStart = true;
                         if (includeStartLine) {

--- a/package.json
+++ b/package.json
@@ -249,7 +249,37 @@
                 "dev"
               ],
               "default": "dev",
-              "description": "Which server instance to query. Defaults to 'dev'."
+              "description": "Which server instance to query. Defaults to 'dev', which is typically preferred."
+            }
+          }
+        }
+      },
+      {
+        "name": "gsl_get_existence_data",
+        "displayName": "Get Existence Data",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getExistenceData",
+        "icon": "$(symbol-misc)",
+        "userDescription": "Retrieve existence (object/item) data from the game server using /se <id>.",
+        "modelDescription": "Sends the /se (show existence) command to the game server for a given existence ID and returns the full existence data output, including the item name, varfields aka properties, flags, and location. Negative IDs are permanent IDs (PID'd) — these are stable references that persist across unload/reload cycles. Positive IDs are temporary and may change. Can target either the Prime (production) or Dev server instance. Defaults to Dev, which is typically preferred. For the room data equivalent, see `gsl_get_room_data`.",
+        "inputSchema": {
+          "type": "object",
+          "required": [
+            "existenceId"
+          ],
+          "properties": {
+            "existenceId": {
+              "type": "integer",
+              "description": "The existence ID to look up. Negative IDs are permanent (PID'd) and stable across reloads."
+            },
+            "instance": {
+              "type": "string",
+              "enum": [
+                "prime",
+                "dev"
+              ],
+              "default": "dev",
+              "description": "Which server instance to query. Defaults to 'dev', which is typically preferred."
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -222,6 +222,37 @@
           "type": "object",
           "properties": {}
         }
+      },
+      {
+        "name": "gsl_get_room_data",
+        "displayName": "Get Room Data",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getRoomData",
+        "icon": "$(compass)",
+        "userDescription": "Retrieve room data from the game server using /sr <room id>.",
+        "modelDescription": "Sends the /sr command to the game server for a given room ID and returns the full room data output, including room name, varfields aka properties, flags, and directions. This does NOT show objects currently in the room, except those explicitly linked in the room description texts. Existence IDs referenced in room text (e.g. $+$-516105D) are PID'd (permanent) and therefore negative — always preserve the negative sign when using them with other tools such as `gsl_get_existence_data`. Can target either the Prime (production) or Dev server instance. Defaults to Dev, which is typically preferred.",
+        "inputSchema": {
+          "type": "object",
+          "required": [
+            "roomId"
+          ],
+          "properties": {
+            "roomId": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "The room ID to look up."
+            },
+            "instance": {
+              "type": "string",
+              "enum": [
+                "prime",
+                "dev"
+              ],
+              "default": "dev",
+              "description": "Which server instance to query. Defaults to 'dev'."
+            }
+          }
+        }
       }
     ],
     "configuration": {


### PR DESCRIPTION
Adds `gsl_get_room_data` and `gsl_get_existence_data` agent tools. Supports prime and dev, defaulting to dev.