### PR TITLE
1.20.2 fixes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -17,6 +17,9 @@ import {
     Range,
     DiagnosticSeverity,
     McpStdioServerDefinition,
+    LanguageModelTextPart,
+    LanguageModelToolResult,
+    CancellationToken,
 } from "vscode";
 
 import { workspace, window, commands, languages, extensions, lm } from "vscode";
@@ -1774,6 +1777,29 @@ export async function activate(context: ExtensionContext) {
                         [context.asAbsolutePath("gsl/mcp/mcpServer.bundle.js")],
                     ),
                 ];
+            },
+        }),
+    );
+
+    // Register agent tool so Copilot can access the current author
+    // without requiring the MCP server to be enabled.
+    context.subscriptions.push(
+        lm.registerTool("gsl_get_current_author", {
+            invoke(
+                _options: unknown,
+                _token: CancellationToken,
+            ): LanguageModelToolResult {
+                const author = GSLExtension.getCurrentAuthor()?.trim();
+                if (!author) {
+                    return new LanguageModelToolResult([
+                        new LanguageModelTextPart(
+                            "Author is not configured. Run 'GSL: User Setup'.",
+                        ),
+                    ]);
+                }
+                return new LanguageModelToolResult([
+                    new LanguageModelTextPart(author),
+                ]);
             },
         }),
     );

--- a/extension.ts
+++ b/extension.ts
@@ -16,9 +16,10 @@ import {
     CodeActionKind,
     Range,
     DiagnosticSeverity,
+    McpStdioServerDefinition,
 } from "vscode";
 
-import { workspace, window, commands, languages, extensions } from "vscode";
+import { workspace, window, commands, languages, extensions, lm } from "vscode";
 
 import {
     GSLDocumentSymbolProvider,
@@ -1760,6 +1761,22 @@ export async function activate(context: ExtensionContext) {
     }
     const pw = await context.secrets.get(GSLX_DEV_PASSWORD);
     if (pw) process.env.GSL_PASSWORD = pw;
+
+    // Register the MCP server definition provider so that consumers
+    // (e.g. GitHub Copilot) can discover and launch gsl-tools.
+    context.subscriptions.push(
+        lm.registerMcpServerDefinitionProvider("gsl.mcpServer", {
+            provideMcpServerDefinitions() {
+                return [
+                    new McpStdioServerDefinition(
+                        "gsl-tools",
+                        process.execPath,
+                        [context.asAbsolutePath("gsl/mcp/mcpServer.bundle.js")],
+                    ),
+                ];
+            },
+        }),
+    );
 
     vsc.checkForNewInstall();
     vsc.checkForUpdatedVersion();

--- a/package.json
+++ b/package.json
@@ -146,6 +146,21 @@
                 "label": "GSL Tools"
             }
         ],
+        "languageModelTools": [
+            {
+                "name": "gsl_get_current_author",
+                "displayName": "Get Current GSL Author",
+                "toolReferenceName": "gsl-get-current-author",
+                "canBeReferencedInPrompt": true,
+                "icon": "$(account)",
+                "userDescription": "Returns the current GSL author from the login config file.",
+                "modelDescription": "Returns the current GSL author value from the user's login configuration file. The author is typically in the format 'AbbreviatedRealName/CharacterName'. Use this tool whenever you need to know who the current developer/author is.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }
+        ],
         "configuration": {
             "type": "object",
             "title": "GSL",

--- a/package.json
+++ b/package.json
@@ -140,15 +140,12 @@
                 "category": "GSL"
             }
         ],
-        "mcpServers": {
-            "gsl-tools": {
-                "type": "stdio",
-                "command": "node",
-                "args": [
-                    "${extensionPath}/gsl/mcp/mcpServer.bundle.js"
-                ]
+        "mcpServerDefinitionProviders": [
+            {
+                "id": "gsl.mcpServer",
+                "label": "GSL Tools"
             }
-        },
+        ],
         "configuration": {
             "type": "object",
             "title": "GSL",


### PR DESCRIPTION
Two fixes:

- Fix issue where extension didn't properly provide the MCP server, requiring manual configuration/troubleshooting.
- Add get-current-author agent tool. This tool used to exist but was moved to the MCP server. However, in retrospect this is a core tool that we shouldn't gate with MCP access. I myself don't have MCP access currently. This allows graceful degradation.