### PR TITLE
Publish 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the GSL Editor extension will be documented in this file.
 
-## [1.20.2] - 2026-05-26
+## [1.21.0] - 2026-05-27
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gsl",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gsl",
-            "version": "1.20.2",
+            "version": "1.20.3",
             "license": "GPL-3.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gsl",
-    "version": "1.20.3",
+    "version": "1.21.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gsl",
-            "version": "1.20.3",
+            "version": "1.21.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gsl",
-    "version": "1.20.1",
+    "version": "1.20.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gsl",
-            "version": "1.20.1",
+            "version": "1.20.2",
             "license": "GPL-3.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsl",
     "displayName": "GSL",
     "description": "GSL Editor",
-    "version": "1.20.3",
+    "version": "1.21.0",
     "publisher": "patricktrant",
     "author": {
         "name": "Patrick Trant",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsl",
     "displayName": "GSL",
     "description": "GSL Editor",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "publisher": "patricktrant",
     "author": {
         "name": "Patrick Trant",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsl",
     "displayName": "GSL",
     "description": "GSL Editor",
-    "version": "1.20.1",
+    "version": "1.20.2",
     "publisher": "patricktrant",
     "author": {
         "name": "Patrick Trant",


### PR DESCRIPTION
Includes an accidental double publish to 1.20.x. Updated to 1.21.0 because this includes a feature so a minor release makes more sense per semver.