### PR TITLE
July 19 Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the GSL Editor extension will be documented in this file.
 
 ## [1.21.2] - 2026-07-19
 
+### Added
+
+- Added an explicit command to install the bundled MCP server at a remembered
+  user-selected path.
+
 ### Fixed
 
 - DR compile checks now use the correct game-specific safety script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the GSL Editor extension will be documented in this file.
 
+## [1.21.2] - 2026-07-19
+
+### Fixed
+
+- DR compile checks now use the correct game-specific safety script.
+
 ## [1.21.1] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ like Claude Code, Codex CLI, or any MCP-compatible client.
 
 1. Run **GSL: User Setup** (`Ctrl+Shift+P` → `GSL: User Setup`) at least once.
    This creates a login config file (typically `~/.gsl/loginConfig.json`).
-2. Note the path to that file — you'll need it below.
+2. Run **GSL: Install MCP Server**. The suggested install path is beside the
+   login config file (typically `~/.gsl/mcpServer.bundle.js`). You can choose a
+   different existing folder, and that path is suggested the next time the
+   command runs. Run the command again after updating the extension to install
+   the latest server.
+3. Note the paths to those files — you'll need them below.
 
 ### Configuration
 

--- a/extension.ts
+++ b/extension.ts
@@ -66,6 +66,7 @@ import { runCopilotCodeReviewCommand } from "./gsl/commands/copilotCodeReview";
 import * as primeService from "./gsl/prime/primeService";
 import { GameInstance, LoginCredentials } from "./gsl/agentToolOrchestrator";
 import { registerNativeTools } from "./gsl/commands/registerNativeTools";
+import { runInstallMcpServerCommand } from "./gsl/commands/installMcpServer";
 
 const rx_script_number = /^\d{1,6}$/;
 const rx_script_number_in_filename = /(\d+)\.gsl/;
@@ -516,6 +517,10 @@ export class VSCodeIntegration {
                 label: "Open Login Config File",
                 name: "gsl.openLoginConfigFile",
             },
+            {
+                label: "Install MCP Server",
+                name: "gsl.installMcpServer",
+            },
         ];
 
         this.outputChannel = window.createOutputChannel("GSL Editor (debug)");
@@ -801,6 +806,13 @@ export class VSCodeIntegration {
         }
         const doc = await workspace.openTextDocument(filePath);
         await window.showTextDocument(doc);
+    }
+
+    private async commandInstallMcpServer() {
+        await runInstallMcpServerCommand({
+            context: this.context,
+            loginConfigPath: GSLExtension.getLoginConfigPath(),
+        });
     }
 
     private async commandCheckDate() {
@@ -1548,6 +1560,12 @@ export class VSCodeIntegration {
             this,
         );
         this.context.subscriptions.push(subscription);
+        subscription = commands.registerCommand(
+            "gsl.installMcpServer",
+            this.commandInstallMcpServer,
+            this,
+        );
+        this.context.subscriptions.push(subscription);
     }
 
     /* public api */
@@ -1808,25 +1826,6 @@ export async function activate(context: ExtensionContext) {
         languages.createDiagnosticCollection("gsl-line-length");
     context.subscriptions.push(lineLengthDiagnostics);
     subscribeToDocumentChanges(context, lineLengthDiagnostics);
-
-    // Copy the MCP server bundle to a stable, version-independent path
-    // alongside the login config file so external consumers (Claude Code,
-    // Codex CLI, etc.) don't break when the extension is updated.
-    const loginConfigPath = GSLExtension.getLoginConfigPath();
-    if (loginConfigPath) {
-        const stableBundlePath = path.join(
-            path.dirname(loginConfigPath),
-            "mcpServer.bundle.js",
-        );
-        const sourceBundlePath = context.asAbsolutePath(
-            "gsl/mcp/mcpServer.bundle.js",
-        );
-        try {
-            fs.copyFileSync(sourceBundlePath, stableBundlePath);
-        } catch (e) {
-            console.error("Failed to copy MCP bundle to stable path:", e);
-        }
-    }
 
     // Register all GSL tools as native VS Code language model tools so
     // Copilot can invoke them without requiring the MCP server.

--- a/gsl/agentToolOrchestrator.ts
+++ b/gsl/agentToolOrchestrator.ts
@@ -253,18 +253,21 @@ export class AgentToolOrchestrator {
     // -- compile check -----------------------------------------------------
 
     /**
-     * Uploads script content to the safety script (S24661) on the dev server
-     * for compilation, and returns the compile results.
+     * Uploads script content to the game's safety script on the dev server for
+     * compilation, and returns the compile results.
      */
     async uploadAndCompileScript(
         content: string,
     ): Promise<ScriptCompileResults> {
-        const SAFETY_SCRIPT = 24661;
         if (!content || content.match(/^\s*$/)) {
             throw new Error("Cannot upload an empty script file.");
         }
-        return this.withClient("dev", async (client) => {
-            const props = await client.modifyScript(SAFETY_SCRIPT, true);
+        const initOptions = await this.initOptionsFor("dev");
+        const safetyScript = initOptions.login.instance.startsWith("DR")
+            ? 16224
+            : 24661;
+        return this.runWithClient("dev", initOptions, async (client) => {
+            const props = await client.modifyScript(safetyScript, true);
             try {
                 const lines = content.split(/\r?\n/);
                 if (lines[lines.length - 1] !== "") {

--- a/gsl/commands/installMcpServer.ts
+++ b/gsl/commands/installMcpServer.ts
@@ -1,0 +1,79 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+
+import { ExtensionContext, window } from "vscode";
+
+const MCP_SERVER_PATH_KEY = "gsl.installMcpServer.destinationPath";
+
+export async function runInstallMcpServerCommand({
+    context,
+    loginConfigPath,
+}: {
+    context: ExtensionContext;
+    loginConfigPath: string | undefined;
+}): Promise<void> {
+    if (!loginConfigPath) {
+        window.showErrorMessage(
+            "Login config file path is not configured. Run 'GSL: User Setup' first.",
+        );
+        return;
+    }
+
+    const sourcePath = context.asAbsolutePath("gsl/mcp/mcpServer.bundle.js");
+    const defaultDestinationPath = path.join(
+        path.dirname(loginConfigPath),
+        "mcpServer.bundle.js",
+    );
+    const enteredPath = await window.showInputBox({
+        prompt: "Where should the MCP server be installed?",
+        value:
+            context.globalState.get<string>(MCP_SERVER_PATH_KEY) ??
+            defaultDestinationPath,
+        ignoreFocusOut: true,
+    });
+    if (!enteredPath) {
+        return;
+    }
+
+    const trimmedPath = enteredPath.trim();
+    const home = process.env.HOME || process.env.USERPROFILE || "";
+    const destinationPath = path.resolve(
+        trimmedPath.startsWith("~")
+            ? path.join(home, trimmedPath.slice(1))
+            : trimmedPath,
+    );
+    const destinationDirectory = path.dirname(destinationPath);
+
+    try {
+        const directoryStats = await fs.stat(destinationDirectory);
+        if (!directoryStats.isDirectory()) {
+            window.showErrorMessage(
+                `MCP server parent path is not a folder: ${destinationDirectory}.`,
+            );
+            return;
+        }
+
+        await fs.copyFile(sourcePath, destinationPath);
+        await context.globalState.update(MCP_SERVER_PATH_KEY, trimmedPath);
+        window.showInformationMessage(
+            `MCP server installed at ${destinationPath}.`,
+        );
+    } catch (error) {
+        console.error("Failed to install MCP server:", error);
+        if (
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+        ) {
+            window.showErrorMessage(
+                `MCP server parent folder does not exist: ${destinationDirectory}.`,
+            );
+            return;
+        }
+        window.showErrorMessage(
+            error instanceof Error
+                ? `Failed to install MCP server (${error.message})`
+                : "Failed to install MCP server.",
+        );
+    }
+}

--- a/gsl/mcp/mcpTools.ts
+++ b/gsl/mcp/mcpTools.ts
@@ -149,7 +149,7 @@ function formatCompileResults(
                   .join("\n")
             : "(No line-level compiler errors were captured.)";
         return [
-            `Compile failed for ${filename} (uploaded as script ${compileResults.script || 24661}).`,
+            `Compile failed for ${filename} (uploaded as script ${compileResults.script}).`,
             `Errors: ${compileResults.errors}, warnings: ${compileResults.warnings}.`,
             "",
             messages,
@@ -160,7 +160,7 @@ function formatCompileResults(
     if (compileResults.status === 4) {
         const bytesRemaining = compileResults.maxBytes - compileResults.bytes;
         return [
-            `Compile OK for ${filename} (uploaded as script ${compileResults.script || 24661}).`,
+            `Compile OK for ${filename} (uploaded as script ${compileResults.script}).`,
             `Warnings: ${compileResults.warnings}.`,
             `Size: ${compileResults.bytes.toLocaleString()} bytes (${bytesRemaining.toLocaleString()} bytes remaining).`,
             compileResults.path ? `Server path: ${compileResults.path}` : "",

--- a/gsl/mcp/toolDefinitions.ts
+++ b/gsl/mcp/toolDefinitions.ts
@@ -129,9 +129,9 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
             "Use this tool whenever the task is to check, compile, or validate GSL script " +
             "compiler errors/warnings. It compiles a local GSL script file on the development server " +
             "and returns compiler output, including line-level errors and warnings, so the " +
-            "model can diagnose and fix compilation problems. The file is uploaded to an " +
-            "ephemeral compilation slot (script 24661). Use this tool when writing scripts " +
-            "or verifying GSL syntax.",
+            "model can diagnose and fix compilation problems. The file is uploaded to the " +
+            "game-specific compilation slot (script 24661 in GemStone or 16224 in " +
+            "DragonRealms). Use this tool when writing scripts or verifying GSL syntax.",
         vscode: {
             displayName: "Compile Check GSL Script",
             toolReferenceName: "gsl-compile-check",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gsl",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gsl",
-            "version": "1.21.0",
+            "version": "1.21.1",
             "license": "GPL-3.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gsl",
-    "version": "1.21.1",
+    "version": "1.21.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gsl",
-            "version": "1.21.1",
+            "version": "1.21.2",
             "license": "GPL-3.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsl",
     "displayName": "GSL",
     "description": "GSL Editor",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "publisher": "patricktrant",
     "author": {
         "name": "Patrick Trant",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsl",
     "displayName": "GSL",
     "description": "GSL Editor",
-    "version": "1.21.1",
+    "version": "1.21.2",
     "publisher": "patricktrant",
     "author": {
         "name": "Patrick Trant",
@@ -137,6 +137,11 @@
             {
                 "command": "gsl.openLoginConfigFile",
                 "title": "Open Login Config File",
+                "category": "GSL"
+            },
+            {
+                "command": "gsl.installMcpServer",
+                "title": "Install MCP Server",
                 "category": "GSL"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
                 "canBeReferencedInPrompt": true,
                 "icon": "$(check-all)",
                 "userDescription": "Compiles a GSL script and returns errors/warnings.",
-                "modelDescription": "Use this tool whenever the task is to check, compile, or validate GSL script compiler errors/warnings. It compiles a local GSL script file on the development server and returns compiler output, including line-level errors and warnings, so the model can diagnose and fix compilation problems. The file is uploaded to an ephemeral compilation slot (script 24661). Use this tool when writing scripts or verifying GSL syntax.",
+                "modelDescription": "Use this tool whenever the task is to check, compile, or validate GSL script compiler errors/warnings. It compiles a local GSL script file on the development server and returns compiler output, including line-level errors and warnings, so the model can diagnose and fix compilation problems. The file is uploaded to the game-specific compilation slot (script 24661 in GemStone or 16224 in DragonRealms). Use this tool when writing scripts or verifying GSL syntax.",
                 "inputSchema": {
                     "type": "object",
                     "required": [


### PR DESCRIPTION
- 1.21.1 rev (this is from a previous release - I had failed to create an MR for the rev).
- Address issue where MCP uploads DragonRealms scripts to the wrong script number when doing a compile check.
- Remove automatic install of MCP - move to command `GSL: Install MCP Server`. This makes more sense and allows the user to specify the target.