### PR TITLE
Proposed 1.21.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,28 @@
 
 All notable changes to the GSL Editor extension will be documented in this file.
 
-## [1.21.2] - 2026-07-19
+## [1.21.2] - 2026-07-26
 
 ### Added
 
-- Added an explicit command to install the bundled MCP server at a remembered
-  user-selected path.
+- Added `GSL: Install MCP Server` to install the bundled MCP server at a
+  remembered user-selected path.
+
+### Changed
+
+- The external MCP server bundle is no longer copied automatically during
+  extension startup. Rerun `GSL: Install MCP Server` after extension updates.
 
 ### Fixed
 
 - DR compile checks now use the correct game-specific safety script.
+- Fixed `GSL: Diff with Live Server` in DR.
+
+### Internal
+
+- Updated esbuild and transitive Hono, body-parser, and fast-uri dependencies.
+- Patched known vulnerabilities in `@hono/node-server`, `brace-expansion`,
+  `js-yaml`, and `serialize-javascript`.
 
 ## [1.21.1] - 2026-06-11
 

--- a/gsl/serverConnection.ts
+++ b/gsl/serverConnection.ts
@@ -5,6 +5,9 @@ const NO_BUFFERING = 0;
 const LINE_BUFFERING = 1;
 
 const DEFAULT_BUFFER_SIZE = 8192;
+// DR Prime embeds the GAME mode tag at the start of its settings XML line,
+// while other instances may send the tag on a line by itself.
+const rx_connection_mode = /<mode\s+id=(["'])(?<mode>GAME|CMGR)\1\s*\/>/;
 
 export enum ServerConnectionMode {
     None,
@@ -187,9 +190,10 @@ export class ServerConnection extends EventEmitter {
     // }
 
     private processLine(line: string) {
-        if (line === '<mode id="GAME"/>') {
+        const mode = line.match(rx_connection_mode)?.groups?.mode;
+        if (mode === "GAME") {
             this.setConnectionMode(this.gameMode);
-        } else if (line === '<mode id="CMGR"/>') {
+        } else if (mode === "CMGR") {
             this.setConnectionMode(ServerConnectionMode.Unbuffered);
         } else {
             this.emit("line", line);

--- a/package-lock.json
+++ b/package-lock.json
@@ -617,12 +617,12 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -1146,16 +1146,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/browser-stdout": {
@@ -2534,9 +2534,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {
@@ -3524,9 +3524,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-            "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,11 @@
         "typescript": "^5.1.6"
     },
     "overrides": {
+        "@hono/node-server": "^2.0.5",
+        "brace-expansion": "^5.0.8",
+        "js-yaml": "^4.3.0",
         "minimatch": "^10.0.1",
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "^7.0.5",
         "diff": "^8.0.3"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsl",
     "displayName": "GSL",
     "description": "GSL Editor",
-    "version": "1.21.2",
+    "version": "1.21.1",
     "publisher": "patricktrant",
     "author": {
         "name": "Patrick Trant",

--- a/test/suite/serverConnection.test.ts
+++ b/test/suite/serverConnection.test.ts
@@ -1,0 +1,66 @@
+import * as assert from "assert";
+
+import {
+    ServerConnection,
+    ServerConnectionMode,
+} from "../../gsl/serverConnection";
+
+suite("ServerConnection", () => {
+    function receive(connection: ServerConnection, text: string): void {
+        (
+            connection as unknown as {
+                socketData(data: Buffer): void;
+            }
+        ).socketData(Buffer.from(text));
+    }
+
+    test("enters game mode when the marker is embedded in settings", () => {
+        const markers = [
+            '<mode id="GAME"/>\n',
+            '<mode id="GAME"/><settingsInfo client="1.0"/>' +
+                '<settings client="1.0"><stream id="main"/></settings>\n',
+            "<mode id='GAME' /><settings></settings>\r\n",
+        ];
+
+        for (const marker of markers) {
+            const connection = new ServerConnection({
+                key: "test",
+                host: "localhost",
+                port: 0,
+            });
+            const modes: ServerConnectionMode[] = [];
+            const text: string[] = [];
+            connection.on("mode", (mode) => modes.push(mode));
+            connection.on("text", (data) => text.push(data));
+
+            receive(connection, marker);
+            receive(connection, "ready>");
+
+            assert.deepStrictEqual(modes, [ServerConnectionMode.Unbuffered]);
+            assert.deepStrictEqual(text, ["ready>"]);
+        }
+    });
+
+    test("detects an embedded game marker split across socket data", () => {
+        const connection = new ServerConnection({
+            key: "test",
+            host: "localhost",
+            port: 0,
+        });
+        const modes: ServerConnectionMode[] = [];
+        const text: string[] = [];
+        connection.on("mode", (mode) => modes.push(mode));
+        connection.on("text", (data) => text.push(data));
+
+        receive(connection, '<mode id="GA');
+        receive(connection, 'ME"/><settings><stream id="main"/>');
+        receive(connection, "</settings>");
+        assert.deepStrictEqual(modes, []);
+
+        receive(connection, "\n");
+        receive(connection, "ready>");
+
+        assert.deepStrictEqual(modes, [ServerConnectionMode.Unbuffered]);
+        assert.deepStrictEqual(text, ["ready>"]);
+    });
+});


### PR DESCRIPTION
## [1.21.2] - 2026-07-26

### Added

- Added `GSL: Install MCP Server` to install the bundled MCP server at a
  remembered user-selected path.

### Changed

- The external MCP server bundle is no longer copied automatically during
  extension startup. Rerun `GSL: Install MCP Server` after extension updates.

### Fixed

- DR compile checks now use the correct game-specific safety script.
- Fixed `GSL: Diff with Live Server` in DR.

### Internal

- Updated esbuild and transitive Hono, body-parser, and fast-uri dependencies.
- Patched known vulnerabilities in `@hono/node-server`, `brace-expansion`,
  `js-yaml`, and `serialize-javascript`.